### PR TITLE
feat/greater: added element-wise greater ( > and >= ) tensor operators

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-06-01
+### Added
+
+- Added greater tensor operator and tests
 ## [Unreleased] - 2023-05-30
 ### Added
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,8 @@
     * [tensor.matmul](apis/operators/tensor/tensor.matmul.md)
     * [tensor.exp](apis/operators/tensor/tensor.exp.md)
     * [tensor.eq](apis/operators/tensor/tensor.eq.md)
+    * [tensor.greater](apis/operators/tensor/tensor.greater.md)
+    * [tensor.greater_equal](apis/operators/tensor/tensor.greater_equal.md)
     * [tensor.abs](apis/operators/tensor/tensor.abs.md)
   * [Neural Network](apis/operators/neural-network/README.md)
     * [nn.relu](apis/operators/neural-network/nn.relu.md)

--- a/docs/apis/compatibility.md
+++ b/docs/apis/compatibility.md
@@ -12,6 +12,7 @@ You can see below the list of current supported ONNX Operators:
 |    Mul     | :white_check_mark: |
 |    Div     | :white_check_mark: |
 |    Equal   | :white_check_mark: |
+|    Greater | :white_check_mark: |
 |    Abs     | :white_check_mark: |
 |    Exp     | :white_check_mark: |
 |   MatMul   | :white_check_mark: |
@@ -32,4 +33,4 @@ Performance optimizations:
 | :----------------: | :----------------: |
 | 8-bit quantization | :white_check_mark: |
 
-Current Operators support: **19/156 (12%)**
+Current Operators support: **20/156 (12%)**

--- a/docs/apis/operators/tensor/tensor.greater.md
+++ b/docs/apis/operators/tensor/tensor.greater.md
@@ -1,0 +1,56 @@
+#tensor.greater
+
+```rust
+fn greater(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+```
+
+Check if each element of the first tensor is greater than the corresponding element of the second tensor.
+The input tensors must have either:
+* Exactly the same shape
+* The same number of dimensions and the length of each dimension is either a common length or 1.
+
+## Args
+
+* `self`(`@Tensor<T>`) - The first tensor to be compared
+* `other`(`@Tensor<T>`) - The second tensor to be compared
+
+## Panics
+
+* Panics if the shapes are not equal or broadcastable
+
+## Returns
+
+A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+
+## Examples
+
+Case 1: Compare tensors with same shape
+
+```rust
+fn greater_example() -> Tensor<usize> {
+// We instantiate two 3D Tensor here.
+// tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+// tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+let tensor_y = u32_tensor_2x2x2_helper();
+let tensor_z = u32_tensor_2x2x2_helper();
+let result = tensor_y.greater(@tensor_z);
+return result;
+}
+>>> [0,0,0,0,0,0,0,1,1]
+```
+
+Case 2: Compare tensors with different shapes
+
+```rust
+fn greater_example() -> Tensor<usize> {
+// tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+// tensor_z = [[0,1,2]]
+let tensor_y = u32_tensor_3x3_helper();
+let tensor_z = u32_tensor_3x1_helper();
+let result = tensor_y.greater(@tensor_z);
+// We could equally do something like:
+// let result = tensor_z.greater(@tensor_y);
+return result;
+}
+>>> [0,0,0,1,1,1,1,1,1]
+```

--- a/docs/apis/operators/tensor/tensor.greater_equal.md
+++ b/docs/apis/operators/tensor/tensor.greater_equal.md
@@ -1,0 +1,56 @@
+#tensor.greater_equal
+
+```rust
+fn greater_equal(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+```
+
+Check if each element of the first tensor is greater than or equal to the corresponding element of the second tensor.
+The input tensors must have either:
+* Exactly the same shape
+* The same number of dimensions and the length of each dimension is either a common length or 1.
+
+## Args
+
+* `self`(`@Tensor<T>`) - The first tensor to be compared
+* `other`(`@Tensor<T>`) - The second tensor to be compared
+
+## Panics
+
+* Panics if the shapes are not equal or broadcastable
+
+## Returns
+
+A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+
+## Examples
+
+Case 1: Compare tensors with same shape
+
+```rust
+fn greater_equal_example() -> Tensor<usize> {
+// We instantiate two 3D Tensor here.
+// tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+// tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+let tensor_y = u32_tensor_2x2x2_helper();
+let tensor_z = u32_tensor_2x2x2_helper();
+let result = tensor_y.greater_equal(@tensor_z);
+return result;
+}
+>>> [1,1,1,1,1,1,0,1,1]
+```
+
+Case 2: Compare tensors with different shapes
+
+```rust
+fn greater_equal_example() -> Tensor<usize> {
+// tensor_y = [[0,1,2],[3,4,5],[0,0,0]]
+// tensor_z = [[0,1,2]]
+let tensor_y = u32_tensor_3x3_helper();
+let tensor_z = u32_tensor_3x1_helper();
+let result = tensor_y.greater_equal(@tensor_z);
+// We could equally do something like:
+// let result = tensor_z.greater_equal(@tensor_y);
+return result;
+}
+>>> [1,1,1,1,1,1,0,0,0]
+```

--- a/src/operators/tensor/math/greater.cairo
+++ b/src/operators/tensor/math/greater.cairo
@@ -1,0 +1,3 @@
+mod greater_i32;
+mod greater_u32;
+mod greater_fp;

--- a/src/operators/tensor/math/greater/greater_fp.cairo
+++ b/src/operators/tensor/math/greater/greater_fp.cairo
@@ -1,0 +1,53 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::fixed_point::types::FixedType;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+
+/// Cf: TensorTrait::greater docstring
+fn greater(y: @Tensor<FixedType>, z: @Tensor<FixedType>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value > z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/greater/greater_i32.cairo
+++ b/src/operators/tensor/math/greater/greater_i32.cairo
@@ -1,0 +1,52 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::signed_integer::i32::i32;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::greater docstring
+fn greater(y: @Tensor<i32>, z: @Tensor<i32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value > z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/greater/greater_u32.cairo
+++ b/src/operators/tensor/math/greater/greater_u32.cairo
@@ -1,0 +1,51 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::greater docstring
+fn greater(y: @Tensor<u32>, z: @Tensor<u32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value > z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/greater_equal.cairo
+++ b/src/operators/tensor/math/greater_equal.cairo
@@ -1,0 +1,3 @@
+mod greater_equal_i32;
+mod greater_equal_u32;
+mod greater_equal_fp;

--- a/src/operators/tensor/math/greater_equal/greater_equal_fp.cairo
+++ b/src/operators/tensor/math/greater_equal/greater_equal_fp.cairo
@@ -1,0 +1,53 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::fixed_point::types::FixedType;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+
+/// Cf: TensorTrait::greater_equal docstring
+fn greater_equal(y: @Tensor<FixedType>, z: @Tensor<FixedType>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value >= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/greater_equal/greater_equal_i32.cairo
+++ b/src/operators/tensor/math/greater_equal/greater_equal_i32.cairo
@@ -1,0 +1,52 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::signed_integer::i32::i32;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::greater_equal docstring
+fn greater_equal(y: @Tensor<i32>, z: @Tensor<i32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value >= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/greater_equal/greater_equal_u32.cairo
+++ b/src/operators/tensor/math/greater_equal/greater_equal_u32.cairo
@@ -1,0 +1,51 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::greater_equal docstring
+fn greater_equal(y: @Tensor<u32>, z: @Tensor<u32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value >= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/tests/operators/math/greater.cairo
+++ b/src/tests/operators/math/greater.cairo
@@ -1,0 +1,3 @@
+mod greater_i32_test;
+mod greater_u32_test;
+mod greater_fp_test;

--- a/src/tests/operators/math/greater/greater_fp_test.cairo
+++ b/src/tests/operators/math/greater/greater_fp_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_fp;
+use orion::operators::tensor::core::TensorTrait;
+use orion::numbers::fixed_point::types::{Fixed,FixedType};
+
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_fp() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(10,false));
+    arr_2.append(Fixed::new(11,false));
+    arr_2.append(Fixed::new(2,true));
+    arr_2.append(Fixed::new(3,true));
+    arr_2.append(Fixed::new(4,false));
+    arr_2.append(Fixed::new(5,false));
+    arr_2.append(Fixed::new(16,false));
+    arr_2.append(Fixed::new(17,false));
+    arr_2.append(Fixed::new(18,false));
+
+
+    let tensor_a = TensorTrait::<FixedType>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_fp_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+    arr_1.append(Fixed::new(9,false));
+    arr_1.append(Fixed::new(10,false));
+    arr_1.append(Fixed::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(0,false));
+    arr_2.append(Fixed::new(1,false));
+    arr_2.append(Fixed::new(2,false));
+    
+    let tensor_a = TensorTrait::<FixedType>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/greater/greater_i32_test.cairo
+++ b/src/tests/operators/math/greater/greater_i32_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_i32;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait,i32::i32};
+
+use orion::operators::tensor::core::TensorTrait;
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_i32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(10,false));
+    arr_2.append(IntegerTrait::new(11,false));
+    arr_2.append(IntegerTrait::new(2,true));
+    arr_2.append(IntegerTrait::new(3,true));
+    arr_2.append(IntegerTrait::new(4,false));
+    arr_2.append(IntegerTrait::new(5,false));
+    arr_2.append(IntegerTrait::new(16,false));
+    arr_2.append(IntegerTrait::new(17,false));
+    arr_2.append(IntegerTrait::new(18,false));
+
+
+    let tensor_a = TensorTrait::<i32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_i32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+    arr_1.append(IntegerTrait::new(9,false));
+    arr_1.append(IntegerTrait::new(10,false));
+    arr_1.append(IntegerTrait::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(0,false));
+    arr_2.append(IntegerTrait::new(1,false));
+    arr_2.append(IntegerTrait::new(2,false));
+    
+    let tensor_a = TensorTrait::<i32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/greater/greater_u32_test.cairo
+++ b/src/tests/operators/math/greater/greater_u32_test.cairo
@@ -1,0 +1,133 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::TensorTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_u32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(7_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(10_u32);
+    arr_2.append(11_u32);
+    arr_2.append(12_u32);
+    arr_2.append(13_u32);
+    arr_2.append(4_u32);
+    arr_2.append(5_u32);
+    arr_2.append(16_u32);
+    arr_2.append(17_u32);
+    arr_2.append(18_u32);
+
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_u32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(5_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    arr_1.append(9_u32);
+    arr_1.append(10_u32);
+    arr_1.append(11_u32);
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(0_u32);
+    arr_2.append(1_u32);
+    arr_2.append(2_u32);
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/greater_equal.cairo
+++ b/src/tests/operators/math/greater_equal.cairo
@@ -1,0 +1,3 @@
+mod greater_equal_i32_test;
+mod greater_equal_u32_test;
+mod greater_equal_fp_test;

--- a/src/tests/operators/math/greater_equal/greater_equal_fp_test.cairo
+++ b/src/tests/operators/math/greater_equal/greater_equal_fp_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_fp;
+use orion::operators::tensor::core::TensorTrait;
+use orion::numbers::fixed_point::types::{Fixed,FixedType};
+
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_fp() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(10,false));
+    arr_2.append(Fixed::new(11,false));
+    arr_2.append(Fixed::new(2,true));
+    arr_2.append(Fixed::new(3,true));
+    arr_2.append(Fixed::new(4,false));
+    arr_2.append(Fixed::new(5,false));
+    arr_2.append(Fixed::new(16,false));
+    arr_2.append(Fixed::new(17,false));
+    arr_2.append(Fixed::new(18,false));
+
+
+    let tensor_a = TensorTrait::<FixedType>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_fp_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+    arr_1.append(Fixed::new(9,false));
+    arr_1.append(Fixed::new(10,false));
+    arr_1.append(Fixed::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(0,false));
+    arr_2.append(Fixed::new(1,false));
+    arr_2.append(Fixed::new(2,false));
+    
+    let tensor_a = TensorTrait::<FixedType>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/greater_equal/greater_equal_i32_test.cairo
+++ b/src/tests/operators/math/greater_equal/greater_equal_i32_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_i32;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait,i32::i32};
+
+use orion::operators::tensor::core::TensorTrait;
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_i32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(10,false));
+    arr_2.append(IntegerTrait::new(11,false));
+    arr_2.append(IntegerTrait::new(2,true));
+    arr_2.append(IntegerTrait::new(3,true));
+    arr_2.append(IntegerTrait::new(4,false));
+    arr_2.append(IntegerTrait::new(5,false));
+    arr_2.append(IntegerTrait::new(16,false));
+    arr_2.append(IntegerTrait::new(17,false));
+    arr_2.append(IntegerTrait::new(18,false));
+
+
+    let tensor_a = TensorTrait::<i32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_i32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+    arr_1.append(IntegerTrait::new(9,false));
+    arr_1.append(IntegerTrait::new(10,false));
+    arr_1.append(IntegerTrait::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(0,false));
+    arr_2.append(IntegerTrait::new(1,false));
+    arr_2.append(IntegerTrait::new(2,false));
+    
+    let tensor_a = TensorTrait::<i32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/greater_equal/greater_equal_u32_test.cairo
+++ b/src/tests/operators/math/greater_equal/greater_equal_u32_test.cairo
@@ -1,0 +1,133 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::TensorTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_u32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(7_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(10_u32);
+    arr_2.append(11_u32);
+    arr_2.append(12_u32);
+    arr_2.append(13_u32);
+    arr_2.append(4_u32);
+    arr_2.append(5_u32);
+    arr_2.append(16_u32);
+    arr_2.append(17_u32);
+    arr_2.append(18_u32);
+
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.greater_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.greater_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_greater_equal_u32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(5_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    arr_1.append(9_u32);
+    arr_1.append(10_u32);
+    arr_1.append(11_u32);
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(0_u32);
+    arr_2.append(1_u32);
+    arr_2.append(2_u32);
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.greater_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_a.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_a.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_a.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_a.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_a.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.greater_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_b.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_b.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_b.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_b.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_b.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Added greater (> and >=)  element-wise operators
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- You can now do `tensor_a.greater(tensor_b)` as well as `tensor_a.greater_equal(tensor_b)`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->