### PR TITLE
feat/less: add less (< and <=)tensor operator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-06-01
+### Added
+
+- Added less tensor operator and tests
+
 ## [Unreleased] - 2023-05-30
 ### Added
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,8 @@
     * [tensor.matmul](apis/operators/tensor/tensor.matmul.md)
     * [tensor.exp](apis/operators/tensor/tensor.exp.md)
     * [tensor.eq](apis/operators/tensor/tensor.eq.md)
+    * [tensor.less](apis/operators/tensor/tensor.less.md)
+    * [tensor.less_equal](apis/operators/tensor/tensor.less_equal.md)
     * [tensor.abs](apis/operators/tensor/tensor.abs.md)
   * [Neural Network](apis/operators/neural-network/README.md)
     * [nn.relu](apis/operators/neural-network/nn.relu.md)

--- a/docs/apis/compatibility.md
+++ b/docs/apis/compatibility.md
@@ -12,6 +12,7 @@ You can see below the list of current supported ONNX Operators:
 |    Mul     | :white_check_mark: |
 |    Div     | :white_check_mark: |
 |    Equal   | :white_check_mark: |
+|    Less    | :white_check_mark: |
 |    Abs     | :white_check_mark: |
 |    Exp     | :white_check_mark: |
 |   MatMul   | :white_check_mark: |
@@ -32,4 +33,4 @@ Performance optimizations:
 | :----------------: | :----------------: |
 | 8-bit quantization | :white_check_mark: |
 
-Current Operators support: **19/156 (12%)**
+Current Operators support: **20/156 (12%)**

--- a/docs/apis/operators/tensor/tensor.less.md
+++ b/docs/apis/operators/tensor/tensor.less.md
@@ -1,0 +1,56 @@
+#tensor.less
+
+```rust
+fn less(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+```
+
+Check if each element of the first tensor is less than the corresponding element of the second tensor.
+The input tensors must have either:
+* Exactly the same shape
+* The same number of dimensions and the length of each dimension is either a common length or 1.
+
+## Args
+
+* `self`(`@Tensor<T>`) - The first tensor to be compared
+* `other`(`@Tensor<T>`) - The second tensor to be compared
+
+## Panics
+
+* Panics if the shapes are not equal or broadcastable
+
+## Returns
+
+A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+
+## Examples
+
+Case 1: Compare tensors with same shape
+
+```rust
+fn less_example() -> Tensor<usize> {
+// We instantiate two 3D Tensor here.
+// tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+// tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+let tensor_y = u32_tensor_2x2x2_helper();
+let tensor_z = u32_tensor_2x2x2_helper();
+let result = tensor_y.less(@tensor_z);
+return result;
+}
+>>> [0,0,0,0,0,0,1,0,0]
+```
+
+Case 2: Compare tensors with different shapes
+
+```rust
+fn less_example() -> Tensor<usize> {
+// tensor_y = [[0,1,2],[3,4,5],[0,0,0]]
+// tensor_z = [[0,1,2]]
+let tensor_y = u32_tensor_3x3_helper();
+let tensor_z = u32_tensor_3x1_helper();
+let result = tensor_y.less(@tensor_z);
+// We could equally do something like:
+// let result = tensor_z.less(@tensor_y);
+return result;
+}
+>>> [0,0,0,0,0,0,0,1,1]
+```

--- a/docs/apis/operators/tensor/tensor.less_equal.md
+++ b/docs/apis/operators/tensor/tensor.less_equal.md
@@ -1,0 +1,56 @@
+#tensor.less_equal
+
+```rust
+fn less_equal(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+```
+
+Check if each element of the first tensor is less than or equal to the corresponding element of the second tensor.
+The input tensors must have either:
+* Exactly the same shape
+* The same number of dimensions and the length of each dimension is either a common length or 1.
+
+## Args
+
+* `self`(`@Tensor<T>`) - The first tensor to be compared
+* `other`(`@Tensor<T>`) - The second tensor to be compared
+
+## Panics
+
+* Panics if the shapes are not equal or broadcastable
+
+## Returns
+
+A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+
+## Examples
+
+Case 1: Compare tensors with same shape
+
+```rust
+fn less_equal_example() -> Tensor<usize> {
+// We instantiate two 3D Tensor here.
+// tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+// tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+let tensor_y = u32_tensor_2x2x2_helper();
+let tensor_z = u32_tensor_2x2x2_helper();
+let result = tensor_y.less_equal(@tensor_z);
+return result;
+}
+>>> [1,1,1,1,1,1,1,0,0]
+```
+
+Case 2: Compare tensors with different shapes
+
+```rust
+fn less_equal_example() -> Tensor<usize> {
+// tensor_y = [[0,1,2],[3,4,5],[0,0,0]]
+// tensor_z = [[0,1,2]]
+let tensor_y = u32_tensor_3x3_helper();
+let tensor_z = u32_tensor_3x1_helper();
+let result = tensor_y.less_equal(@tensor_z);
+// We could equally do something like:
+// let result = tensor_z.less_equal(@tensor_y);
+return result;
+}
+>>> [1,1,1,0,0,0,1,1,1]
+```

--- a/src/operators/tensor/core.cairo
+++ b/src/operators/tensor/core.cairo
@@ -656,6 +656,122 @@ trait TensorTrait<T> {
     /// ```
     ///
     fn eq(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+    /// #tensor.less
+    ///
+    /// ```rust
+    ///     fn less(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+    /// ```
+    ///
+    /// Check if each element of the first tensor is less than the corresponding element of the second tensor.
+    /// The input tensors must have either:
+    /// * Exactly the same shape
+    /// * The same number of dimensions and the length of each dimension is either a common length or 1.
+    /// 
+    /// ## Args
+    ///
+    /// * `self`(`@Tensor<T>`) - The first tensor to be compared
+    /// * `other`(`@Tensor<T>`) - The second tensor to be compared
+    ///
+    /// ## Panics
+    ///
+    /// * Panics if the shapes are not equal or broadcastable
+    ///
+    /// ## Returns
+    ///
+    /// A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+    ///
+    /// ## Examples
+    ///
+    /// Case 1: Compare tensors with same shape
+    ///
+    /// ```rust
+    /// fn less_example() -> Tensor<usize> {
+    ///     // We instantiate two 3D Tensor here.
+    ///     // tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+    ///     // tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+    ///     let tensor_y = u32_tensor_2x2x2_helper();
+    ///     let tensor_z = u32_tensor_2x2x2_helper();
+    ///     let result = tensor_y.less(@tensor_z);
+    ///     return result;
+    /// }
+    /// >>> [0,0,0,0,0,0,1,0,0]
+    /// ```
+    ///
+    /// Case 2: Compare tensors with different shapes
+    ///
+    /// ```rust
+    /// fn less_example() -> Tensor<usize> {
+    ///     // tensor_y = [[0,1,2],[3,4,5],[0,0,0]]
+    ///     // tensor_z = [[0,1,2]]       
+    ///     let tensor_y = u32_tensor_3x3_helper();
+    ///     let tensor_z = u32_tensor_3x1_helper();
+    ///     let result = tensor_y.less(@tensor_z);
+    ///     // We could equally do something like:
+    ///     // let result = tensor_z.less(@tensor_y);
+    ///     return result;
+    /// }
+    /// >>> [0,0,0,0,0,0,0,1,1]
+    /// ```
+    ///
+    fn less(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+    /// #tensor.less_equal
+    ///
+    /// ```rust
+    ///     fn less_equal(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
+    /// ```
+    ///
+    /// Check if each element of the first tensor is less than or equal to the corresponding element of the second tensor.
+    /// The input tensors must have either:
+    /// * Exactly the same shape
+    /// * The same number of dimensions and the length of each dimension is either a common length or 1.
+    /// 
+    /// ## Args
+    ///
+    /// * `self`(`@Tensor<T>`) - The first tensor to be compared
+    /// * `other`(`@Tensor<T>`) - The second tensor to be compared
+    ///
+    /// ## Panics
+    ///
+    /// * Panics if the shapes are not equal or broadcastable
+    ///
+    /// ## Returns
+    ///
+    /// A new `Tensor<usize>` of booleans (0 or 1) with the same shape as the broadcasted inputs.
+    ///
+    /// ## Examples
+    ///
+    /// Case 1: Compare tensors with same shape
+    ///
+    /// ```rust
+    /// fn less_equal_example() -> Tensor<usize> {
+    ///     // We instantiate two 3D Tensor here.
+    ///     // tensor_y = [[0,1,2],[3,4,5],[6,7,8]]
+    ///     // tensor_z = [[0,1,2],[3,4,5],[9,1,5]]
+    ///     let tensor_y = u32_tensor_2x2x2_helper();
+    ///     let tensor_z = u32_tensor_2x2x2_helper();
+    ///     let result = tensor_y.less_equal(@tensor_z);
+    ///     return result;
+    /// }
+    /// >>> [1,1,1,1,1,1,1,0,0]
+    /// ```
+    ///
+    /// Case 2: Compare tensors with different shapes
+    ///
+    /// ```rust
+    /// fn less_equal_example() -> Tensor<usize> {
+    ///     // tensor_y = [[0,1,2],[3,4,5],[0,0,0]]
+    ///     // tensor_z = [[0,1,2]]       
+    ///     let tensor_y = u32_tensor_3x3_helper();
+    ///     let tensor_z = u32_tensor_3x1_helper();
+    ///     let result = tensor_y.less_equal(@tensor_z);
+    ///     // We could equally do something like:
+    ///     // let result = tensor_z.less_equal(@tensor_y);
+    ///     return result;
+    /// }
+    /// >>> [1,1,1,0,0,0,1,1,1]
+    /// ```
+    ///
+    fn less_equal(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<usize>;
     /// #tensor.abs
     ///
     /// ```rust

--- a/src/operators/tensor/implementations/impl_tensor_fp.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_fp.cairo
@@ -10,6 +10,8 @@ use orion::operators::tensor::core::{
 use orion::operators::tensor::math::min::min_fp::min_in_tensor;
 use orion::operators::tensor::math::max::max_fp::max_in_tensor;
 use orion::operators::tensor::math::equal::equal_fp::equal;
+use orion::operators::tensor::math::less::less_fp::less;
+use orion::operators::tensor::math::less_equal::less_equal_fp::less_equal;
 use orion::operators::tensor::math::abs::abs_fp::abs;
 use orion::operators::tensor::math::reduce_sum::reduce_sum_fp::reduce_sum;
 use orion::operators::tensor::math::argmax::argmax_fp::argmax;
@@ -74,6 +76,14 @@ impl FixedTypeTensor of TensorTrait<FixedType> {
 
     fn eq(self:@Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<usize> {
         equal(self, other)
+    }
+
+    fn less(self:@Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<usize> {
+        less(self, other)
+    }
+
+    fn less_equal(self:@Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<usize> {
+        less_equal(self, other)
     }
 
     fn abs(self:@Tensor<FixedType>) -> Tensor<FixedType> {

--- a/src/operators/tensor/implementations/impl_tensor_i32.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_i32.cairo
@@ -13,6 +13,8 @@ use orion::operators::tensor::math::max::max_i32::max_in_tensor;
 use orion::operators::tensor::math::reduce_sum::reduce_sum_i32::reduce_sum;
 use orion::operators::tensor::math::argmax::argmax_i32::argmax;
 use orion::operators::tensor::math::equal::equal_i32::equal;
+use orion::operators::tensor::math::less::less_i32::less;
+use orion::operators::tensor::math::less_equal::less_equal_i32::less_equal;
 use orion::operators::tensor::math::abs::abs_i32::abs;
 use orion::operators::tensor::linalg::matmul::matmul_i32::matmul;
 use orion::operators::tensor::linalg::transpose::transpose_i32::transpose;
@@ -75,6 +77,14 @@ impl i32Tensor of TensorTrait<i32> {
 
     fn eq(self:@Tensor<i32>, other: @Tensor<i32>) -> Tensor<usize> {
         equal(self, other)
+    }
+
+    fn less(self:@Tensor<i32>, other: @Tensor<i32>) -> Tensor<usize> {
+        less(self, other)
+    }
+
+    fn less_equal(self:@Tensor<i32>, other: @Tensor<i32>) -> Tensor<usize> {
+        less_equal(self, other)
     }
 
     fn abs(self: @Tensor<i32>) -> Tensor<i32> {

--- a/src/operators/tensor/implementations/impl_tensor_u32.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_u32.cairo
@@ -13,6 +13,8 @@ use orion::operators::tensor::math::reduce_sum::reduce_sum_u32::reduce_sum;
 use orion::operators::tensor::math::argmax::argmax_u32::argmax;
 use orion::operators::tensor::linalg::matmul::matmul_u32::matmul;
 use orion::operators::tensor::math::equal::equal_u32::equal;
+use orion::operators::tensor::math::less::less_u32::less;
+use orion::operators::tensor::math::less_equal::less_equal_u32::less_equal;
 use orion::operators::tensor::math::abs::abs_u32::abs;
 use orion::operators::tensor::linalg::transpose::transpose_u32::transpose;
 use orion::operators::tensor::math::exp::exp_u32::exp;
@@ -75,6 +77,15 @@ impl U32Tensor of TensorTrait<u32> {
     fn eq(self:@Tensor<u32>, other: @Tensor<u32>) -> Tensor<usize> {
         equal(self, other)
     }
+
+    fn less(self:@Tensor<u32>, other: @Tensor<u32>) -> Tensor<usize> {
+        less(self, other)
+    }
+
+    fn less_equal(self:@Tensor<u32>, other: @Tensor<u32>) -> Tensor<usize> {
+        less_equal(self, other)
+    }
+
 
     fn abs(self: @Tensor<u32>) -> Tensor<u32> {
         abs(self)

--- a/src/operators/tensor/math.cairo
+++ b/src/operators/tensor/math.cairo
@@ -5,4 +5,6 @@ mod argmax;
 mod exp;
 mod arithmetic;
 mod equal;
+mod less;
+mod less_equal;
 mod abs;

--- a/src/operators/tensor/math/less.cairo
+++ b/src/operators/tensor/math/less.cairo
@@ -1,0 +1,3 @@
+mod less_i32;
+mod less_u32;
+mod less_fp;

--- a/src/operators/tensor/math/less/less_fp.cairo
+++ b/src/operators/tensor/math/less/less_fp.cairo
@@ -1,0 +1,53 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::fixed_point::types::FixedType;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+
+/// Cf: TensorTrait::less docstring
+fn less(y: @Tensor<FixedType>, z: @Tensor<FixedType>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value < z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/less/less_i32.cairo
+++ b/src/operators/tensor/math/less/less_i32.cairo
@@ -1,0 +1,53 @@
+use core::debug::PrintTrait;
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::signed_integer::i32::i32;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::less docstring
+fn less(y: @Tensor<i32>, z: @Tensor<i32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+
+        if y_value < z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/less/less_u32.cairo
+++ b/src/operators/tensor/math/less/less_u32.cairo
@@ -1,0 +1,51 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::less docstring
+fn less(y: @Tensor<u32>, z: @Tensor<u32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value < z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/less_equal.cairo
+++ b/src/operators/tensor/math/less_equal.cairo
@@ -1,0 +1,3 @@
+mod less_equal_i32;
+mod less_equal_u32;
+mod less_equal_fp;

--- a/src/operators/tensor/math/less_equal/less_equal_fp.cairo
+++ b/src/operators/tensor/math/less_equal/less_equal_fp.cairo
@@ -1,0 +1,53 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::fixed_point::types::FixedType;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+
+/// Cf: TensorTrait::less_equal docstring
+fn less_equal(y: @Tensor<FixedType>, z: @Tensor<FixedType>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value <= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/less_equal/less_equal_i32.cairo
+++ b/src/operators/tensor/math/less_equal/less_equal_i32.cairo
@@ -1,0 +1,52 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::numbers::signed_integer::i32::i32;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::less_equal docstring
+fn less_equal(y: @Tensor<i32>, z: @Tensor<i32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value <= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/operators/tensor/math/less_equal/less_equal_u32.cairo
+++ b/src/operators/tensor/math/less_equal/less_equal_u32.cairo
@@ -1,0 +1,51 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+use array::SpanTrait;
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait};
+use orion::utils::check_gas;
+use orion::operators::tensor::helpers::check_compatibility;
+
+/// Cf: TensorTrait::less_equal docstring
+fn less_equal(y: @Tensor<u32>, z: @Tensor<u32>) -> Tensor<usize> {
+
+    check_compatibility(*y.shape,*z.shape);
+
+    let mut data_result = ArrayTrait::<usize>::new();
+    let (mut smaller, mut bigger, order_swapped) = if (*y.data).len() < (*z.data).len() { 
+        (y, z, true) 
+    } else { 
+        (z, y, false)
+    };
+
+    let mut bigger_data = *bigger.data;
+    let mut smaller_data = *smaller.data;
+    let mut smaller_index = 0;
+ 
+    loop {
+        check_gas();
+
+        if bigger_data.len() == 0 {
+            break ();
+        };
+
+        let bigger_current_index = *bigger_data.pop_front().unwrap();
+        let smaller_current_index = *smaller_data.at(smaller_index);
+
+        let (y_value, z_value) = if order_swapped {
+            (smaller_current_index, bigger_current_index)
+        } else {
+            (bigger_current_index, smaller_current_index)
+        };
+        
+        if y_value <= z_value {
+            data_result.append(1);
+        } else {
+            data_result.append(0);
+        };
+        
+        smaller_index = (1 + smaller_index) % smaller_data.len() ;
+    };
+
+    return TensorTrait::<usize>::new(*bigger.shape, data_result.span());
+}

--- a/src/tests/operators/math.cairo
+++ b/src/tests/operators/math.cairo
@@ -6,4 +6,6 @@ mod signed_integer_test;
 mod fixed_point_test;
 mod exp_test;
 mod equal;
+mod less;
+mod less_equal;
 mod abs;

--- a/src/tests/operators/math/less.cairo
+++ b/src/tests/operators/math/less.cairo
@@ -1,0 +1,3 @@
+mod less_i32_test;
+mod less_u32_test;
+mod less_fp_test;

--- a/src/tests/operators/math/less/less_fp_test.cairo
+++ b/src/tests/operators/math/less/less_fp_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_fp;
+use orion::operators::tensor::core::TensorTrait;
+use orion::numbers::fixed_point::types::{Fixed,FixedType};
+
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_fp() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(10,false));
+    arr_2.append(Fixed::new(11,false));
+    arr_2.append(Fixed::new(2,true));
+    arr_2.append(Fixed::new(3,true));
+    arr_2.append(Fixed::new(4,false));
+    arr_2.append(Fixed::new(5,false));
+    arr_2.append(Fixed::new(16,false));
+    arr_2.append(Fixed::new(17,false));
+    arr_2.append(Fixed::new(18,false));
+
+
+    let tensor_a = TensorTrait::<FixedType>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_fp_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+    arr_1.append(Fixed::new(9,false));
+    arr_1.append(Fixed::new(10,false));
+    arr_1.append(Fixed::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(0,false));
+    arr_2.append(Fixed::new(1,false));
+    arr_2.append(Fixed::new(2,false));
+    
+    let tensor_a = TensorTrait::<FixedType>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/less/less_i32_test.cairo
+++ b/src/tests/operators/math/less/less_i32_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_i32;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait,i32::i32};
+
+use orion::operators::tensor::core::TensorTrait;
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_i32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(10,false));
+    arr_2.append(IntegerTrait::new(11,false));
+    arr_2.append(IntegerTrait::new(2,true));
+    arr_2.append(IntegerTrait::new(3,true));
+    arr_2.append(IntegerTrait::new(4,false));
+    arr_2.append(IntegerTrait::new(5,false));
+    arr_2.append(IntegerTrait::new(16,false));
+    arr_2.append(IntegerTrait::new(17,false));
+    arr_2.append(IntegerTrait::new(18,false));
+
+
+    let tensor_a = TensorTrait::<i32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_i32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+    arr_1.append(IntegerTrait::new(9,false));
+    arr_1.append(IntegerTrait::new(10,false));
+    arr_1.append(IntegerTrait::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(0,false));
+    arr_2.append(IntegerTrait::new(1,false));
+    arr_2.append(IntegerTrait::new(2,false));
+    
+    let tensor_a = TensorTrait::<i32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/less/less_u32_test.cairo
+++ b/src/tests/operators/math/less/less_u32_test.cairo
@@ -1,0 +1,133 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::TensorTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_u32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(7_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(10_u32);
+    arr_2.append(11_u32);
+    arr_2.append(12_u32);
+    arr_2.append(13_u32);
+    arr_2.append(4_u32);
+    arr_2.append(5_u32);
+    arr_2.append(16_u32);
+    arr_2.append(17_u32);
+    arr_2.append(18_u32);
+
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_u32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(5_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    arr_1.append(9_u32);
+    arr_1.append(10_u32);
+    arr_1.append(11_u32);
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(0_u32);
+    arr_2.append(1_u32);
+    arr_2.append(2_u32);
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less(@tensor_a);
+    assert(*result_a.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_a.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less(@tensor_b);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/less_equal.cairo
+++ b/src/tests/operators/math/less_equal.cairo
@@ -1,0 +1,3 @@
+mod less_equal_i32_test;
+mod less_equal_u32_test;
+mod less_equal_fp_test;

--- a/src/tests/operators/math/less_equal/less_equal_fp_test.cairo
+++ b/src/tests/operators/math/less_equal/less_equal_fp_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_fp;
+use orion::operators::tensor::core::TensorTrait;
+use orion::numbers::fixed_point::types::{Fixed,FixedType};
+
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_fp() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(10,false));
+    arr_2.append(Fixed::new(11,false));
+    arr_2.append(Fixed::new(2,true));
+    arr_2.append(Fixed::new(3,true));
+    arr_2.append(Fixed::new(4,false));
+    arr_2.append(Fixed::new(5,false));
+    arr_2.append(Fixed::new(16,false));
+    arr_2.append(Fixed::new(17,false));
+    arr_2.append(Fixed::new(18,false));
+
+
+    let tensor_a = TensorTrait::<FixedType>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_fp_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<FixedType>::new();
+    arr_1.append(Fixed::new(0,false));
+    arr_1.append(Fixed::new(1,false));
+    arr_1.append(Fixed::new(2,false));
+    arr_1.append(Fixed::new(3,false));
+    arr_1.append(Fixed::new(4,false));
+    arr_1.append(Fixed::new(5,false));
+    arr_1.append(Fixed::new(6,false));
+    arr_1.append(Fixed::new(7,false));
+    arr_1.append(Fixed::new(8,false));
+    arr_1.append(Fixed::new(9,false));
+    arr_1.append(Fixed::new(10,false));
+    arr_1.append(Fixed::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<FixedType>::new();
+    arr_2.append(Fixed::new(0,false));
+    arr_2.append(Fixed::new(1,false));
+    arr_2.append(Fixed::new(2,false));
+    
+    let tensor_a = TensorTrait::<FixedType>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<FixedType>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/less_equal/less_equal_i32_test.cairo
+++ b/src/tests/operators/math/less_equal/less_equal_i32_test.cairo
@@ -1,0 +1,134 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_i32;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait,i32::i32};
+
+use orion::operators::tensor::core::TensorTrait;
+
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_i32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+
+    
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(10,false));
+    arr_2.append(IntegerTrait::new(11,false));
+    arr_2.append(IntegerTrait::new(2,true));
+    arr_2.append(IntegerTrait::new(3,true));
+    arr_2.append(IntegerTrait::new(4,false));
+    arr_2.append(IntegerTrait::new(5,false));
+    arr_2.append(IntegerTrait::new(16,false));
+    arr_2.append(IntegerTrait::new(17,false));
+    arr_2.append(IntegerTrait::new(18,false));
+
+
+    let tensor_a = TensorTrait::<i32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_a.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_i32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<i32>::new();
+    arr_1.append(IntegerTrait::new(0,false));
+    arr_1.append(IntegerTrait::new(1,false));
+    arr_1.append(IntegerTrait::new(2,false));
+    arr_1.append(IntegerTrait::new(3,false));
+    arr_1.append(IntegerTrait::new(4,false));
+    arr_1.append(IntegerTrait::new(5,false));
+    arr_1.append(IntegerTrait::new(6,false));
+    arr_1.append(IntegerTrait::new(7,false));
+    arr_1.append(IntegerTrait::new(8,false));
+    arr_1.append(IntegerTrait::new(9,false));
+    arr_1.append(IntegerTrait::new(10,false));
+    arr_1.append(IntegerTrait::new(11,false));
+
+    let mut arr_2 = ArrayTrait::<i32>::new();
+    arr_2.append(IntegerTrait::new(0,false));
+    arr_2.append(IntegerTrait::new(1,false));
+    arr_2.append(IntegerTrait::new(2,false));
+    
+    let tensor_a = TensorTrait::<i32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<i32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}

--- a/src/tests/operators/math/less_equal/less_equal_u32_test.cairo
+++ b/src/tests/operators/math/less_equal/less_equal_u32_test.cairo
@@ -1,0 +1,133 @@
+use array::SpanTrait;
+use array::{ArrayTrait};
+use orion::operators::tensor::implementations::impl_tensor_u32;
+use orion::operators::tensor::core::TensorTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_u32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(7_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(10_u32);
+    arr_2.append(11_u32);
+    arr_2.append(12_u32);
+    arr_2.append(13_u32);
+    arr_2.append(4_u32);
+    arr_2.append(5_u32);
+    arr_2.append(16_u32);
+    arr_2.append(17_u32);
+    arr_2.append(18_u32);
+
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes.span(), arr_2.span());
+
+    let result_a = tensor_a.less_equal(@tensor_b);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_b.less_equal(@tensor_a);
+    assert(*result_b.data.at(0) == 0, 'result[0] = 0');
+    assert(*result_b.data.at(1) == 0, 'result[1] = 0');
+    assert(*result_b.data.at(2) == 0, 'result[2] = 0');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_b.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn tensor_less_equal_u32_broadcast() {
+    let mut sizes_1 = ArrayTrait::new();
+    sizes_1.append(4);
+    sizes_1.append(3);
+
+    let mut sizes_2 = ArrayTrait::new();
+    sizes_2.append(1);
+    sizes_2.append(3);
+
+    let mut arr_1 = ArrayTrait::<u32>::new();
+    arr_1.append(0_u32);
+    arr_1.append(1_u32);
+    arr_1.append(2_u32);
+    arr_1.append(3_u32);
+    arr_1.append(4_u32);
+    arr_1.append(5_u32);
+    arr_1.append(6_u32);
+    arr_1.append(7_u32);
+    arr_1.append(8_u32);
+    arr_1.append(9_u32);
+    arr_1.append(10_u32);
+    arr_1.append(11_u32);
+
+    let mut arr_2 = ArrayTrait::<u32>::new();
+    arr_2.append(0_u32);
+    arr_2.append(1_u32);
+    arr_2.append(2_u32);
+    
+    
+    let tensor_a = TensorTrait::<u32>::new(sizes_1.span(), arr_1.span());
+    let tensor_b = TensorTrait::<u32>::new(sizes_2.span(), arr_2.span());
+
+    let result_a = tensor_b.less_equal(@tensor_a);
+    assert(*result_a.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_a.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_a.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_a.data.at(3) == 1, 'result[3] = 1');
+    assert(*result_a.data.at(4) == 1, 'result[4] = 1');
+    assert(*result_a.data.at(5) == 1, 'result[5] = 1');
+    assert(*result_a.data.at(6) == 1, 'result[6] = 1');
+    assert(*result_a.data.at(7) == 1, 'result[7] = 1');
+    assert(*result_a.data.at(8) == 1, 'result[8] = 1');
+    assert(*result_a.data.at(9) == 1, 'result[9] = 1');
+    assert(*result_a.data.at(10) == 1, 'result[10] = 1');
+    assert(*result_a.data.at(11) == 1, 'result[11] = 1');
+
+    assert(result_a.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+
+    let result_b = tensor_a.less_equal(@tensor_b);
+    assert(*result_b.data.at(0) == 1, 'result[0] = 1');
+    assert(*result_b.data.at(1) == 1, 'result[1] = 1');
+    assert(*result_b.data.at(2) == 1, 'result[2] = 1');
+    assert(*result_b.data.at(3) == 0, 'result[3] = 0');
+    assert(*result_b.data.at(4) == 0, 'result[4] = 0');
+    assert(*result_b.data.at(5) == 0, 'result[5] = 0');
+    assert(*result_b.data.at(6) == 0, 'result[6] = 0');
+    assert(*result_b.data.at(7) == 0, 'result[7] = 0');
+    assert(*result_b.data.at(8) == 0, 'result[8] = 0');
+    assert(*result_b.data.at(9) == 0, 'result[9] = 0');
+    assert(*result_b.data.at(10) == 0, 'result[10] = 0');
+    assert(*result_b.data.at(11) == 0, 'result[11] = 0');
+
+    assert(result_b.data.len() == tensor_a.data.len(), 'tensor length mismatch');
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Added less (< and <=) operators
## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- You can now do `tensor_a.less(tensor_b)` as well as `tensor_a.less_equal(tensor_b)`


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This PR needs #77 to be merged before all tests pass