### PR TITLE
Remove check range at the creation of new fixed point

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - 2023-06-07
 
+### Changed
+
+- Remove the check range from the creation of a new fixed point, 
+  so that we can use fp for wide calculations. 
+  A future PR will restore the check range with a better design.
+
+## [Unreleased] - 2023-06-07
+
 ### Added
 - Added ceil operator
 

--- a/src/numbers/fixed_point/implementations/impl_16x16.cairo
+++ b/src/numbers/fixed_point/implementations/impl_16x16.cairo
@@ -17,11 +17,7 @@ const MAX: u128 = 4294967295; // 2 ** 32 - 1
 
 impl FP16x16Impl of FixedTrait {
     fn new(mag: u128, sign: bool) -> FixedType {
-        if sign == true {
-            assert(mag <= MAX, 'fixed type: out of range');
-        } else {
-            assert(mag <= MAX - 1_u128, 'fixed type: out of range');
-        }
+        // TODO: check range
         return FixedType { mag: mag, sign: sign };
     }
 

--- a/src/numbers/fixed_point/implementations/impl_8x23.cairo
+++ b/src/numbers/fixed_point/implementations/impl_8x23.cairo
@@ -17,11 +17,7 @@ const MAX: u128 = 2147483647; // 2 ** 31 - 1
 
 impl FP8x23Impl of FixedTrait {
     fn new(mag: u128, sign: bool) -> FixedType {
-        if sign == true {
-            assert(mag <= MAX, 'fixed type: out of range');
-        } else {
-            assert(mag <= MAX - 1_u128, 'fixed type: out of range');
-        }
+        // TODO: check range
         return FixedType { mag: mag, sign: sign };
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
- In real use cases of neural network, we need to perform intermediary wide-ranging calculations with fixed points. But the checking will create an error if the result is out of range.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This PR removes the check range from the creation of a new fixed point, so that we can use fp for wide calculations. A future RP will restore the checking range with a better design.

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->