### PR TITLE
Fix #107: add supports for 1d tensors 

### DIFF
--- a/src/operators/tensor/math/argmax.cairo
+++ b/src/operators/tensor/math/argmax.cairo
@@ -1,3 +1,4 @@
 mod argmax_i32;
 mod argmax_u32;
 mod argmax_fp;
+mod helpers;

--- a/src/operators/tensor/math/argmax/argmax_fp/fp16x16.cairo
+++ b/src/operators/tensor/math/argmax/argmax_fp/fp16x16.cairo
@@ -7,12 +7,17 @@ use orion::numbers::fixed_point::implementations::impl_16x16;
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmax::helpers::{find_argmax_1D, find_argmax};
 use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmax docstring
 fn argmax(self: @Tensor<FixedType>, axis: usize) -> Tensor<usize> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
 
+    if (*self.shape).len() == 1 { 
+        return find_argmax_1D(self, axis, true, false);
+    }
+    
     let mut output_data = ArrayTrait::new();
 
     let output_shape = reduce_output_shape(*self.shape, axis, false);
@@ -36,48 +41,4 @@ fn argmax(self: @Tensor<FixedType>, axis: usize) -> Tensor<usize> {
     };
 
     return TensorTrait::<usize>::new(output_shape, output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the maximum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the maximum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `max_value` - The current maximum value found along the axis.
-/// * `argmax` - The current index of the maximum value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the maximum value along the specified axis.
-fn find_argmax(
-    input: @Tensor<FixedType>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    max_value: FixedType,
-    argmax: usize
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmax;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_max_value, new_argmax) = if ele > max_value {
-        (ele, axis_index)
-    } else {
-        (max_value, argmax)
-    };
-
-    return find_argmax(
-        input, output_indices, axis, axis_index + 1_usize, new_max_value, new_argmax
-    );
 }

--- a/src/operators/tensor/math/argmax/argmax_i32.cairo
+++ b/src/operators/tensor/math/argmax/argmax_i32.cairo
@@ -5,11 +5,16 @@ use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::{impl_tensor_i32, impl_tensor_u32};
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmax::helpers::{find_argmax_1D, find_argmax};
 use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmax docstring
 fn argmax(self: @Tensor<i32>, axis: usize) -> Tensor<usize> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+    
+    if (*self.shape).len() == 1 { 
+        return find_argmax_1D(self, axis, true, false);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -34,48 +39,4 @@ fn argmax(self: @Tensor<i32>, axis: usize) -> Tensor<usize> {
     };
 
     return TensorTrait::<usize>::new(output_shape, output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the maximum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the maximum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `max_value` - The current maximum value found along the axis.
-/// * `argmax` - The current index of the maximum value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the maximum value along the specified axis.
-fn find_argmax(
-    input: @Tensor<i32>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    max_value: i32,
-    argmax: usize
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmax;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_max_value, new_argmax) = if ele > max_value {
-        (ele, axis_index)
-    } else {
-        (max_value, argmax)
-    };
-
-    return find_argmax(
-        input, output_indices, axis, axis_index + 1_usize, new_max_value, new_argmax
-    );
 }

--- a/src/operators/tensor/math/argmax/argmax_u32.cairo
+++ b/src/operators/tensor/math/argmax/argmax_u32.cairo
@@ -4,11 +4,16 @@ use array::SpanTrait;
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmax::helpers::{find_argmax_1D, find_argmax};
 use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmax docstring
 fn argmax(self: @Tensor<u32>, axis: usize) -> Tensor<usize> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+
+    if (*self.shape).len() == 1 { 
+        return find_argmax_1D(self, axis, true, false);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -31,48 +36,4 @@ fn argmax(self: @Tensor<u32>, axis: usize) -> Tensor<usize> {
     };
 
     return TensorTrait::<usize>::new(output_shape, output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the maximum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the maximum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `max_value` - The current maximum value found along the axis.
-/// * `argmax` - The current index of the maximum value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the maximum value along the specified axis.
-fn find_argmax(
-    input: @Tensor<u32>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    max_value: u32,
-    argmax: usize
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmax;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_max_value, new_argmax) = if ele > max_value {
-        (ele, axis_index)
-    } else {
-        (max_value, argmax)
-    };
-
-    return find_argmax(
-        input, output_indices, axis, axis_index + 1_usize, new_max_value, new_argmax
-    );
 }

--- a/src/operators/tensor/math/argmax/helpers.cairo
+++ b/src/operators/tensor/math/argmax/helpers.cairo
@@ -1,0 +1,116 @@
+use core::debug::PrintTrait;
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+
+use orion::operators::tensor::implementations:: impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index};
+use orion::operators::tensor::helpers::{reduce_output_shape,combine_indices};
+use orion::utils::check_gas;
+
+/// Helper function that finds the index of the maximum value in a flat tensor.
+///
+/// # Arguments
+/// * `input` - The input tensor.
+/// * `axis` - The axis along which to find the maximum value.
+/// * `keepdims` - Whether to keep the reduced dimension or not.
+/// * `select_last_index` - Whether to select last occurrence of the max value along the axis.
+///
+/// # Panics
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A usize value representing the index of the maximum value along the specified axis.
+fn find_argmax_1D< T, 
+    impl TPartialOrd: PartialOrd<T>,
+    impl TPartialEq: PartialEq<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+>(
+    input: @Tensor<T>,
+    axis: usize, 
+    keepdims:bool, 
+    select_last_index: bool
+    ) -> Tensor<usize>{
+
+        let mut output_data = ArrayTrait::<usize>::new();
+        let mut data = *input.data;
+
+        let mut max = *data.pop_front().unwrap();
+        let mut max_index = 0_usize;
+        let mut count = 0_usize;
+        loop {
+            check_gas();
+            
+            if data.len() == 0 {
+                break ();
+            };
+
+            count += 1;
+
+            let current_value = *data.pop_front().unwrap();
+            if current_value > max {
+                max = current_value;
+                max_index = count;
+
+            } else {
+                if select_last_index & (current_value == max) {
+                    max_index = count;
+                }
+            }; 
+        };
+
+        output_data.append(max_index);
+
+        return TensorTrait::<usize>::new(reduce_output_shape(*input.shape, axis, keepdims), output_data.span(), *input.extra);
+}
+
+
+
+/// Recursive helper function that finds the index of the maximum value along a specific axis.
+///
+/// # Arguments
+/// * `input` - The input tensor.
+/// * `output_indices` - A span of output indices.
+/// * `axis` - The axis along which to find the maximum value.
+/// * `axis_index` - The current index along the specified axis.
+/// * `max_value` - The current maximum value found along the axis.
+/// * `argmax` - The current index of the maximum value along the axis.
+///
+/// # Panics
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A usize value representing the index of the maximum value along the specified axis.
+fn find_argmax< T, 
+    impl TPartialOrd: PartialOrd<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+>(
+    input: @Tensor<T>,
+    output_indices: Span<usize>,
+    axis: usize,
+    axis_index: usize,
+    max_value: T,
+    argmax: usize
+) -> usize {
+    check_gas();
+
+    if axis_index == *(*input.shape).at(axis) {
+        return argmax;
+    }
+
+    let input_indices = combine_indices(output_indices, axis_index, axis);
+    let input_index = ravel_index(*input.shape, input_indices);
+    let ele = *(*input.data).at(input_index);
+
+    let (new_max_value, new_argmax) = if ele > max_value {
+        (ele, axis_index)
+    } else {
+        (max_value, argmax)
+    };
+
+    return find_argmax(
+        input, output_indices, axis, axis_index + 1_usize, new_max_value, new_argmax
+    );
+}

--- a/src/operators/tensor/math/argmin.cairo
+++ b/src/operators/tensor/math/argmin.cairo
@@ -1,3 +1,4 @@
 mod argmin_i32;
 mod argmin_u32;
 mod argmin_fp;
+mod helpers;

--- a/src/operators/tensor/math/argmin/argmin_fp/fp16x16.cairo
+++ b/src/operators/tensor/math/argmin/argmin_fp/fp16x16.cairo
@@ -7,6 +7,7 @@ use orion::numbers::fixed_point::implementations::impl_16x16;
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmin::helpers::{find_argmin_1D,find_argmin};
 use orion::utils::check_gas;
 
 
@@ -29,6 +30,10 @@ fn argmin(
     };
     
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+
+    if (*self.shape).len() == 1 { 
+        return find_argmin_1D(self, axis, true, select_last_index);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -57,52 +62,3 @@ fn argmin(
     return TensorTrait::<usize>::new(reduce_output_shape(*self.shape, axis, keepdims), output_data.span(), *self.extra);
 }
 
-/// Recursive helper function that finds the index of the minimum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the minimum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `min_value` - The current minimum value found along the axis.
-/// * `argmin` - The current index of the minimum value along the axis.
-/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the minimum value along the specified axis.
-fn find_argmin(
-    input: @Tensor<FixedType>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    min_value: FixedType,
-    argmin: usize,
-    select_last_index: bool
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmin;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_min_value, new_argmin) = if ele < min_value {
-        (ele, axis_index)
-    } else {
-        if select_last_index & (ele == min_value) {
-            (ele, axis_index)
-        } else {
-            (min_value, argmin)
-        }
-    };
-
-    return find_argmin(
-        input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
-    );
-}

--- a/src/operators/tensor/math/argmin/argmin_fp/fp8x23.cairo
+++ b/src/operators/tensor/math/argmin/argmin_fp/fp8x23.cairo
@@ -6,6 +6,7 @@ use orion::numbers::fixed_point::implementations::impl_8x23;
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmin::helpers::{find_argmin_1D,find_argmin};
 use orion::utils::check_gas;
 
 
@@ -28,6 +29,10 @@ fn argmin(
     };
 
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+    
+    if (*self.shape).len() == 1 { 
+        return find_argmin_1D(self, axis, true, select_last_index);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -54,54 +59,4 @@ fn argmin(
     };
 
     return TensorTrait::<usize>::new(reduce_output_shape(*self.shape, axis, keepdims), output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the minimum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the minimum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `min_value` - The current minimum value found along the axis.
-/// * `argmin` - The current index of the minimum value along the axis.
-/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the minimum value along the specified axis.
-fn find_argmin(
-    input: @Tensor<FixedType>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    min_value: FixedType,
-    argmin: usize,
-    select_last_index: bool
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmin;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_min_value, new_argmin) = if ele < min_value {
-        (ele, axis_index)
-    } else {
-        if select_last_index & (ele == min_value) {
-            (ele, axis_index)
-        } else {
-            (min_value, argmin)
-        }
-    };
-
-    return find_argmin(
-        input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
-    );
 }

--- a/src/operators/tensor/math/argmin/argmin_i32.cairo
+++ b/src/operators/tensor/math/argmin/argmin_i32.cairo
@@ -1,8 +1,5 @@
-use core::option::OptionTrait;
-use core::clone::Clone;
 use array::ArrayTrait;
 use array::SpanTrait;
-use debug::PrintTrait;
 
 use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::{impl_tensor_i32, impl_tensor_u32};
@@ -12,31 +9,23 @@ use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmin docstring
 fn argmin(
-    mut self: @Tensor<i32>, 
+    self: @Tensor<i32>, 
     axis: usize, 
     keepdims: Option<bool>, 
     select_last_index:Option<bool> 
     ) -> Tensor<usize> {
 
-    let keepdims = if (*self.shape).len() == 1 {
-            false
-        } else {
-            match keepdims {
-                Option::Some(val) => val,
-                Option::None(_) => true,
-            }
+    let keepdims = match keepdims {
+        Option::Some(val) => val,
+        Option::None(_) => true,
     };
-    
+
     let select_last_index = match select_last_index {
         Option::Some(val) => val,
         Option::None(_) => false,
     };
     
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
-
-    if (*self.shape).len() == 1 {
-        self = make_2d(self);
-    } 
 
     let mut output_data = ArrayTrait::new();
 
@@ -114,18 +103,4 @@ fn find_argmin(
     return find_argmin(
         input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
     );
-}
-
-/// Convert a 1D tensor to a 2D tensor with a second dimension of size 1.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-///
-/// # Returns
-/// * The input tensor reshaped to have an additional dimension of size 1
-fn make_2d(input: @Tensor<i32>) -> @Tensor<i32> {
-    let mut new_shape = ArrayTrait::new();
-    new_shape.append(*(*input.shape).at(0));
-    new_shape.append(1);
-    @input.reshape(new_shape.span())
 }

--- a/src/operators/tensor/math/argmin/argmin_i32.cairo
+++ b/src/operators/tensor/math/argmin/argmin_i32.cairo
@@ -1,5 +1,8 @@
+use core::option::OptionTrait;
+use core::clone::Clone;
 use array::ArrayTrait;
 use array::SpanTrait;
+use debug::PrintTrait;
 
 use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::{impl_tensor_i32, impl_tensor_u32};
@@ -9,23 +12,31 @@ use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmin docstring
 fn argmin(
-    self: @Tensor<i32>, 
+    mut self: @Tensor<i32>, 
     axis: usize, 
     keepdims: Option<bool>, 
     select_last_index:Option<bool> 
     ) -> Tensor<usize> {
 
-    let keepdims = match keepdims {
-        Option::Some(val) => val,
-        Option::None(_) => true,
+    let keepdims = if (*self.shape).len() == 1 {
+            false
+        } else {
+            match keepdims {
+                Option::Some(val) => val,
+                Option::None(_) => true,
+            }
     };
-
+    
     let select_last_index = match select_last_index {
         Option::Some(val) => val,
         Option::None(_) => false,
     };
     
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+
+    if (*self.shape).len() == 1 {
+        self = make_2d(self);
+    } 
 
     let mut output_data = ArrayTrait::new();
 
@@ -103,4 +114,18 @@ fn find_argmin(
     return find_argmin(
         input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
     );
+}
+
+/// Convert a 1D tensor to a 2D tensor with a second dimension of size 1.
+///
+/// # Arguments
+/// * `input` - The input tensor.
+///
+/// # Returns
+/// * The input tensor reshaped to have an additional dimension of size 1
+fn make_2d(input: @Tensor<i32>) -> @Tensor<i32> {
+    let mut new_shape = ArrayTrait::new();
+    new_shape.append(*(*input.shape).at(0));
+    new_shape.append(1);
+    @input.reshape(new_shape.span())
 }

--- a/src/operators/tensor/math/argmin/argmin_i32.cairo
+++ b/src/operators/tensor/math/argmin/argmin_i32.cairo
@@ -5,6 +5,7 @@ use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::{impl_tensor_i32, impl_tensor_u32};
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmin::helpers::{find_argmin_1D,find_argmin};
 use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmin docstring
@@ -26,6 +27,10 @@ fn argmin(
     };
     
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+    
+    if (*self.shape).len() == 1 { 
+        return find_argmin_1D(self, axis, true, select_last_index);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -53,54 +58,4 @@ fn argmin(
     };
 
     return TensorTrait::<usize>::new(reduce_output_shape(*self.shape, axis, keepdims), output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the minimum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the minimum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `min_value` - The current minimum value found along the axis.
-/// * `argmin` - The current index of the minimum value along the axis.
-/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the minimum value along the specified axis.
-fn find_argmin(
-    input: @Tensor<i32>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    min_value: i32,
-    argmin: usize,
-    select_last_index: bool
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmin;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_min_value, new_argmin) = if ele < min_value {
-        (ele, axis_index)
-    } else {
-        if select_last_index & (ele == min_value) {
-            (ele, axis_index)
-        } else {
-            (min_value, argmin)
-        }
-    };
-
-    return find_argmin(
-        input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
-    );
 }

--- a/src/operators/tensor/math/argmin/argmin_u32.cairo
+++ b/src/operators/tensor/math/argmin/argmin_u32.cairo
@@ -4,6 +4,7 @@ use array::SpanTrait;
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index, unravel_index};
 use orion::operators::tensor::helpers::{reduce_output_shape, len_from_shape, combine_indices};
+use orion::operators::tensor::math::argmin::helpers::{find_argmin_1D,find_argmin};
 use orion::utils::check_gas;
 
 /// Cf: TensorTrait::argmin docstring
@@ -25,6 +26,10 @@ fn argmin(
     };
     
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
+
+    if (*self.shape).len() == 1 { 
+        return find_argmin_1D(self, axis, true, select_last_index);
+    }
 
     let mut output_data = ArrayTrait::new();
 
@@ -51,54 +56,4 @@ fn argmin(
     };
 
     return TensorTrait::<usize>::new(reduce_output_shape(*self.shape, axis, keepdims), output_data.span(), *self.extra);
-}
-
-/// Recursive helper function that finds the index of the minimum value along a specific axis.
-///
-/// # Arguments
-/// * `input` - The input tensor.
-/// * `output_indices` - A span of output indices.
-/// * `axis` - The axis along which to find the minimum value.
-/// * `axis_index` - The current index along the specified axis.
-/// * `min_value` - The current minimum value found along the axis.
-/// * `argmin` - The current index of the minimum value along the axis.
-/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
-///
-/// # Panics
-/// * Panics if gas limit is exceeded during execution.
-///
-/// # Returns
-/// * A usize value representing the index of the minimum value along the specified axis.
-fn find_argmin(
-    input: @Tensor<u32>,
-    output_indices: Span<usize>,
-    axis: usize,
-    axis_index: usize,
-    min_value: u32,
-    argmin: usize,
-    select_last_index: bool
-) -> usize {
-    check_gas();
-
-    if axis_index == *(*input.shape).at(axis) {
-        return argmin;
-    }
-
-    let input_indices = combine_indices(output_indices, axis_index, axis);
-    let input_index = ravel_index(*input.shape, input_indices);
-    let ele = *(*input.data).at(input_index);
-
-    let (new_min_value, new_argmin) = if ele < min_value {
-        (ele, axis_index)
-    } else {
-        if select_last_index & (ele == min_value) {
-            (ele, axis_index)
-        } else {
-            (min_value, argmin)
-        }
-    };
-
-    return find_argmin(
-        input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
-    );
 }

--- a/src/operators/tensor/math/argmin/helpers.cairo
+++ b/src/operators/tensor/math/argmin/helpers.cairo
@@ -1,0 +1,124 @@
+use core::debug::PrintTrait;
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+
+use orion::operators::tensor::implementations:: impl_tensor_u32;
+use orion::operators::tensor::core::{Tensor, TensorTrait, ravel_index};
+use orion::operators::tensor::helpers::{reduce_output_shape,combine_indices};
+use orion::utils::check_gas;
+
+/// Helper function that finds the index of the minimum value in a flat tensor.
+///
+/// # Arguments
+/// * `input` - The input tensor.
+/// * `axis` - The axis along which to find the minimum value.
+/// * `keepdims` - Whether to keep the reduced dimension or not.
+/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
+///
+/// # Panics
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A usize value representing the index of the minimum value along the specified axis.
+fn find_argmin_1D< T, 
+    impl TPartialOrd: PartialOrd<T>,
+    impl TPartialEq: PartialEq<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+>(
+    input: @Tensor<T>,
+    axis: usize, 
+    keepdims:bool, 
+    select_last_index: bool
+    ) -> Tensor<usize>{
+
+        let mut output_data = ArrayTrait::<usize>::new();
+        let mut data = *input.data;
+
+        let mut min = *data.pop_front().unwrap();
+        let mut min_index = 0_usize;
+        let mut count = 0_usize;
+        loop {
+            check_gas();
+            
+            if data.len() == 0 {
+                break ();
+            };
+
+            count += 1;
+
+            let current_value = *data.pop_front().unwrap();
+            if current_value < min {
+                min = current_value;
+                min_index = count;
+
+            } else {
+                if select_last_index & (current_value == min) {
+                    min_index = count;
+                }
+            }; 
+        };
+
+        output_data.append(min_index);
+
+        return TensorTrait::<usize>::new(reduce_output_shape(*input.shape, axis, keepdims), output_data.span(), *input.extra);
+}
+
+
+
+/// Recursive helper function that finds the index of the minimum value along a specific axis.
+///
+/// # Arguments
+/// * `input` - The input tensor.
+/// * `output_indices` - A span of output indices.
+/// * `axis` - The axis along which to find the minimum value.
+/// * `axis_index` - The current index along the specified axis.
+/// * `min_value` - The current minimum value found along the axis.
+/// * `argmin` - The current index of the minimum value along the axis.
+/// * `select_last_index` - Whether to select last occurrence of the min value along the axis.
+///
+/// # Panics
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A usize value representing the index of the minimum value along the specified axis.
+fn find_argmin< T, 
+    impl TPartialOrd: PartialOrd<T>,
+    impl TPartialEq: PartialEq<T>,
+    impl TCopy: Copy<T>,
+    impl TDrop: Drop<T>,
+>(
+    input: @Tensor<T>,
+    output_indices: Span<usize>,
+    axis: usize,
+    axis_index: usize,
+    min_value: T,
+    argmin: usize,
+    select_last_index: bool
+) -> usize {
+    check_gas();
+
+    if axis_index == *(*input.shape).at(axis) {
+        return argmin;
+    }
+
+    let input_indices = combine_indices(output_indices, axis_index, axis);
+    let input_index = ravel_index(*input.shape, input_indices);
+    let ele = *(*input.data).at(input_index);
+
+    let (new_min_value, new_argmin) = if ele < min_value {
+        (ele, axis_index)
+    } else {
+        if select_last_index & (ele == min_value) {
+            (ele, axis_index)
+        } else {
+            (min_value, argmin)
+        }
+    };
+
+    return find_argmin(
+        input, output_indices, axis, axis_index + 1_usize, new_min_value, new_argmin,select_last_index
+    );
+}
+

--- a/src/tests/operators/math/argmax_test.cairo
+++ b/src/tests/operators/math/argmax_test.cairo
@@ -1,8 +1,45 @@
-use array::SpanTrait;
+use array::{ArrayTrait,SpanTrait};
 
 use orion::operators::tensor::implementations::impl_tensor_i32;
-use orion::operators::tensor::core::TensorTrait;
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::tests::operators::tensor::helpers::{i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
+
+
+#[test]
+#[available_gas(20000000)]
+fn tensor1x3_argmax() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, false));
+    data.append(IntegerTrait::new(2_u32, false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmax(0);
+    assert(*result.data.at(0) == 2, 'result[0] = 2');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, true));
+    data.append(IntegerTrait::new(2_u32, true));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmax(0);
+    assert(*result.data.at(0) == 0, 'result[0] = 0');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+}
+
 
 #[test]
 #[available_gas(20000000)]

--- a/src/tests/operators/math/argmin/argmin_fp_test.cairo
+++ b/src/tests/operators/math/argmin/argmin_fp_test.cairo
@@ -5,6 +5,42 @@ use orion::numbers::fixed_point::implementations::impl_8x23;
 
 use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
 
+
+#[test]
+#[available_gas(20000000)]
+fn tensor1x3_argmin_fp() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new(0, false));
+    data.append(FixedTrait::new(1, false));
+    data.append(FixedTrait::new(2, false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 0, 'result[0] = 0');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new(0, false));
+    data.append(FixedTrait::new(1, false));
+    data.append(FixedTrait::new(2, true));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 2, 'result[0] = 2');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+}
+
+
 #[test]
 #[available_gas(20000000)]
 fn tensor2x2_argmin_fp() {

--- a/src/tests/operators/math/argmin/argmin_i32_test.cairo
+++ b/src/tests/operators/math/argmin/argmin_i32_test.cairo
@@ -3,7 +3,7 @@ use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::impl_tensor_i32;
 use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
 
-use orion::tests::operators::tensor::helpers::{i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
+use orion::tests::operators::tensor::helpers::{i32_tensor_1x3_helper,i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
 
 #[test]
 #[available_gas(20000000)]
@@ -120,4 +120,10 @@ fn tensor_argmin_keepdims_i32(){
     assert(result.data.len() == 2, 'length == 2');
     assert(result.shape.len() == 2, 'result.shape.len() == 2');
 
+
+    let tensor = i32_tensor_1x3_helper();
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 0, 'result[0] = 0');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
 }

--- a/src/tests/operators/math/argmin/argmin_i32_test.cairo
+++ b/src/tests/operators/math/argmin/argmin_i32_test.cairo
@@ -3,7 +3,7 @@ use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::impl_tensor_i32;
 use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
 
-use orion::tests::operators::tensor::helpers::{i32_tensor_1x3_helper,i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
+use orion::tests::operators::tensor::helpers::{i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
 
 #[test]
 #[available_gas(20000000)]
@@ -120,10 +120,4 @@ fn tensor_argmin_keepdims_i32(){
     assert(result.data.len() == 2, 'length == 2');
     assert(result.shape.len() == 2, 'result.shape.len() == 2');
 
-
-    let tensor = i32_tensor_1x3_helper();
-    let result = tensor.argmin(0,Option::None(()),Option::None(()));
-    assert(*result.data.at(0) == 0, 'result[0] = 0');
-    assert(result.data.len() == 1, 'length == 1');
-    assert(result.shape.len() == 1, 'result.shape.len() == 1');
 }

--- a/src/tests/operators/math/argmin/argmin_i32_test.cairo
+++ b/src/tests/operators/math/argmin/argmin_i32_test.cairo
@@ -3,7 +3,42 @@ use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
 use orion::operators::tensor::implementations::impl_tensor_i32;
 use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
 
-use orion::tests::operators::tensor::helpers::{i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
+use orion::tests::operators::tensor::helpers::{i32_tensor_1x3_helper,i32_tensor_2x2_helper, i32_tensor_2x2x2_helper};
+
+#[test]
+#[available_gas(20000000)]
+fn tensor1x3_argmin_i32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, false));
+    data.append(IntegerTrait::new(2_u32, false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 0, 'result[0] = 0');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, false));
+    data.append(IntegerTrait::new(2_u32, true));
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 2, 'result[0] = 2');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+}
+
 
 #[test]
 #[available_gas(20000000)]

--- a/src/tests/operators/math/argmin/argmin_u32_test.cairo
+++ b/src/tests/operators/math/argmin/argmin_u32_test.cairo
@@ -3,6 +3,40 @@ use array::{ArrayTrait,SpanTrait};
 use orion::operators::tensor::implementations::impl_tensor_u32;
 use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
 
+#[test]
+#[available_gas(20000000)]
+fn tensor1x3_argmin_u32() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(0);
+    data.append(1);
+    data.append(2);
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<u32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 0, 'result[0] = 0');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+
+
+    let mut data = ArrayTrait::new();
+    data.append(1);
+    data.append(2);
+    data.append(0);
+    let extra = Option::<ExtraParams>::None(());
+
+    let tensor = TensorTrait::<u32>::new(sizes.span(), data.span(), extra);
+    
+    let result = tensor.argmin(0,Option::None(()),Option::None(()));
+    assert(*result.data.at(0) == 2, 'result[0] = 2');
+    assert(result.data.len() == 1, 'length == 1');
+    assert(result.shape.len() == 1, 'result.shape.len() == 1');
+}
+
 
 #[test]
 #[available_gas(20000000)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
 let tensor = i32_tensor_1x3_helper();
 let result = tensor.argmin(0,Option::None(()),Option::None(()));

>>>> panicked with [('shape cannot be empty') ]
```
Issue Number: #107 

## What is the new behavior?


<!-- Please describe the behavior or changes that are being added by this PR. -->

```
 let tensor = i32_tensor_1x3_helper();
 let result = tensor.argmin(0,Option::None(()),Option::None(()));
>>>> [0]
```


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

Generic helper functions were added to avoid repetition 