### PR TITLE
Onehot encoding for tensors with tests

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -71,6 +71,7 @@
     * [tensor.tanh](framework/operators/tensor/tensor.tanh.md)
     * [tensor.atan](framework/operators/tensor/tensor.atan.md)
     * [tensor.acos](framework/operators/tensor/tensor.acos.md)
+    * [tensor.onehot](framework/operators/tensor/tensor.onehot.md)
   * [Neural Network](framework/operators/neural-network/README.md)
     * [nn.relu](framework/operators/neural-network/nn.relu.md)
     * [nn.leaky\_relu](framework/operators/neural-network/nn.leaky\_relu.md)

--- a/docs/framework/compatibility.md
+++ b/docs/framework/compatibility.md
@@ -45,6 +45,7 @@ You can see below the list of current supported ONNX Operators:
 |           [ACosh](operators/tensor/tensor.acosh.md)           | :white\_check\_mark: |
 |            [Tanh](operators/tensor/tensor.tanh.md)            | :white\_check\_mark: |
 |            [Acos](operators/tensor/tensor.acos.md)            | :white\_check\_mark: |
+|        [Onehot](operators/tensor/tensor.onehot.md)            | :white\_check\_mark: |
 | [QuantizeLinear](performance/performance.quantize\_linear.md) | :white\_check\_mark: |
 | [DequantizeLinear](performance/performance.quantize\_linear.md) | :white\_check\_mark: |
 
@@ -55,4 +56,4 @@ Performance optimizations:
 | :----------------: | :------------------: |
 | 8-bit quantization | :white\_check\_mark: |
 
-Current Operators support: **41/156 (26%)**
+Current Operators support: **42/156 (27%)**

--- a/docs/framework/operators/tensor/tensor.onehot.md
+++ b/docs/framework/operators/tensor/tensor.onehot.md
@@ -1,0 +1,42 @@
+# tensor.onehot
+
+```rust 
+   fn onehot(self: @Tensor<T>, depth: usize, axis: Option<usize>, values: Span<usize>) -> Tensor<usize>;
+```
+
+Produces one-hot tensor based on input.
+
+## Args
+
+* `self`(`@Tensor<T>`) - The input tensor.
+* `depth`(`usize`) - Scalar or Rank 1 tensor containing exactly one element, specifying the number of classes in one-hot tensor.
+* `axis`(`Option<bool>`) - Axis along which one-hot representation in added. Default: axis=-1.
+* `values`(`Span<usize>`) - Rank 1 tensor containing exactly two elements, in the format [off_value, on_value]   
+
+## Panics
+
+* Panics if values is not equal to 2.
+
+## Returns 
+
+A new `Tensor<T>` one-hot encode of the input tensor.
+
+## Example
+
+```rust
+fn onehot_example() -> Tensor<FixedType> {
+    // We instantiate a 1D Tensor here.
+    // [[0,1],[2,3]]
+    let tensor = u32_tensor_1x3_helper();
+    let mut values = ArrayTrait::new();
+    values.append(0);
+    values.append(1);
+    let depth = 3;
+    let axis: Option<usize> = Option::None(());
+    result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    return result;
+}
+>>> [[1. 0. 0.]
+     [0. 1. 0.]
+     [0. 0. 1.]]
+```

--- a/src/numbers/fixed_point/implementations/impl_16x16.cairo
+++ b/src/numbers/fixed_point/implementations/impl_16x16.cairo
@@ -124,6 +124,8 @@ impl FP16x16Impl of FixedTrait {
     fn acos(self: FixedType) -> FixedType {
         return math_16x16::acos(self);
     }
+
+
 }
 
 impl FP16x16Print of PrintTrait<FixedType> {

--- a/src/operators/tensor/core.cairo
+++ b/src/operators/tensor/core.cairo
@@ -1638,7 +1638,55 @@ trait TensorTrait<T> {
     /// ```
     ///
     fn acos(self: @Tensor<T>) -> Tensor<FixedType>;
+    /// # tensor.onehot
+    ///
+    /// ```rust 
+    ///    fn onehot(self: @Tensor<T>, depth: usize, axis: Option<usize>, values: Span<usize>) -> Tensor<usize>;
+    /// ```
+    ///
+    /// Produces one-hot tensor based on input.
+    ///
+    /// ## Args
+    ///
+    /// * `self`(`@Tensor<T>`) - The input tensor.
+    /// * `depth`(`usize`) - Scalar or Rank 1 tensor containing exactly one element, specifying the number of classes in one-hot tensor.
+    /// * `axis`(`Option<bool>`) - Axis along which one-hot representation in added. Default: axis=-1.
+    /// * `values`(`Span<usize>`) - Rank 1 tensor containing exactly two elements, in the format [off_value, on_value]   
+    ///
+    /// ## Panics
+    ///
+    /// * Panics if values is not equal to 2.
+    ///
+    /// ## Returns 
+    ///
+    /// A new `Tensor<T>` one-hot encode of the input tensor.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// fn onehot_example() -> Tensor<FixedType> {
+    ///     // We instantiate a 1D Tensor here.
+    ///     // [[0,1],[2,3]]
+    ///     let tensor = u32_tensor_1x3_helper();
+    ///     let mut values = ArrayTrait::new();
+    ///     values.append(0);
+    ///     values.append(1);
+    ///     let depth = 3;
+    ///     let axis: Option<usize> = Option::None(());
+    ///     result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    ///     return result;
+    /// }
+    /// >>> [[1. 0. 0.]
+    ///      [0. 1. 0.]
+    ///      [0. 0. 1.]]
+    /// ```
+    ///
+    fn onehot(
+        self: @Tensor<T>, depth: usize, axis: Option<usize>, values: Span<usize>
+    ) -> Tensor<T>;
+
 }
+
 
 /// Cf: TensorTrait::new docstring
 fn new_tensor<T>(shape: Span<usize>, data: Span<T>, extra: Option<ExtraParams>) -> Tensor<T> {

--- a/src/operators/tensor/implementations/impl_tensor_fp.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_fp.cairo
@@ -39,6 +39,7 @@ use orion::operators::tensor::math::cos::cos_fp::core::cos;
 use orion::operators::tensor::math::asin::asin_fp::core::asin;
 use orion::operators::tensor::math::atan::atan_fp::core::atan;
 use orion::operators::tensor::math::acos::acos_fp::core::acos;
+use orion::operators::tensor::math::onehot::onehot_fp::core::onehot;
 
 
 impl Tensor_fp of TensorTrait<FixedType> {
@@ -190,6 +191,12 @@ impl Tensor_fp of TensorTrait<FixedType> {
 
     fn acos(self: @Tensor<FixedType>) -> Tensor<FixedType> {
         acos(self).unwrap()
+    }
+
+    fn onehot(
+        self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, values: Span<usize>
+    ) -> Tensor<FixedType> {
+        onehot(self, depth, axis, values).unwrap()
     }
 }
 

--- a/src/operators/tensor/implementations/impl_tensor_i32.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_i32.cairo
@@ -42,6 +42,9 @@ use orion::operators::tensor::math::cos::cos_i32::core::cos_i32;
 use orion::operators::tensor::math::asin::asin_i32::core::asin_i32;
 use orion::operators::tensor::math::atan::atan_i32::core::atan_i32;
 use orion::operators::tensor::math::acos::acos_i32::core::acos_i32;
+use orion::operators::tensor::math::onehot::onehot_i32::onehot;
+
+
 
 
 impl Tensor_i32 of TensorTrait<i32> {
@@ -186,6 +189,13 @@ impl Tensor_i32 of TensorTrait<i32> {
     fn acos(self: @Tensor<i32>) -> Tensor<FixedType> {
         acos_i32(self).unwrap()
     }
+
+    fn onehot(
+        self: @Tensor<i32>, depth: usize, axis: Option<usize>, values: Span<usize>
+    ) -> Tensor<i32> {
+        onehot(self, depth, axis, values)
+    }
+    
 }
 
 /// Implements addition for `Tensor<i32>` using the `Add` trait.

--- a/src/operators/tensor/implementations/impl_tensor_i8.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_i8.cairo
@@ -43,6 +43,7 @@ use orion::operators::tensor::math::cos::cos_i8::core::cos_i8;
 use orion::operators::tensor::math::asin::asin_i8::core::asin_i8;
 use orion::operators::tensor::math::atan::atan_i8::core::atan_i8;
 use orion::operators::tensor::math::acos::acos_i8::core::acos_i8;
+use orion::operators::tensor::math::onehot::onehot_i8::onehot;
 
 
 impl Tensor_i8 of TensorTrait<i8> {
@@ -186,6 +187,12 @@ impl Tensor_i8 of TensorTrait<i8> {
 
     fn acos(self: @Tensor<i8>) -> Tensor<FixedType> {
         acos_i8(self).unwrap()
+    }
+
+    fn onehot(
+        self: @Tensor<i8>, depth: usize, axis: Option<usize>, values: Span<usize>
+    ) -> Tensor<i8> {
+        onehot(self, depth, axis, values)
     }
 }
 

--- a/src/operators/tensor/implementations/impl_tensor_u32.cairo
+++ b/src/operators/tensor/implementations/impl_tensor_u32.cairo
@@ -41,6 +41,7 @@ use orion::operators::tensor::math::cos::cos_u32::core::cos_u32;
 use orion::operators::tensor::math::asin::asin_u32::core::asin_u32;
 use orion::operators::tensor::math::atan::atan_u32::core::atan_u32;
 use orion::operators::tensor::math::acos::acos_u32::core::acos_u32;
+use orion::operators::tensor::math::onehot::onehot_u32::onehot;
 
 
 impl Tensor_u32 of TensorTrait<u32> {
@@ -185,6 +186,12 @@ impl Tensor_u32 of TensorTrait<u32> {
     
     fn acos(self: @Tensor<u32>) -> Tensor<FixedType> {
         acos_u32(self).unwrap()
+    }
+
+    fn onehot(
+        self: @Tensor<u32>, depth: usize, axis: Option<usize>, values: Span<usize>
+    ) -> Tensor<u32> {
+        onehot(self, depth, axis, values)
     }
 }
 

--- a/src/operators/tensor/math.cairo
+++ b/src/operators/tensor/math.cairo
@@ -25,3 +25,5 @@ mod acosh;
 mod asinh;
 mod atan;
 mod acos;
+mod onehot;
+

--- a/src/operators/tensor/math/onehot.cairo
+++ b/src/operators/tensor/math/onehot.cairo
@@ -1,0 +1,4 @@
+mod onehot_i8;
+mod onehot_i32;
+mod onehot_u32;
+mod onehot_fp;

--- a/src/operators/tensor/math/onehot/onehot_fp.cairo
+++ b/src/operators/tensor/math/onehot/onehot_fp.cairo
@@ -1,0 +1,3 @@
+mod core;
+mod fp8x23;
+mod fp16x16;

--- a/src/operators/tensor/math/onehot/onehot_fp/core.cairo
+++ b/src/operators/tensor/math/onehot/onehot_fp/core.cairo
@@ -1,0 +1,26 @@
+use core::option::OptionTrait;
+use orion::numbers::fixed_point::core::{FixedType, FixedImpl};
+use orion::operators::tensor::core::Tensor;
+use orion::operators::tensor::math::onehot::onehot_fp::fp8x23;
+use orion::operators::tensor::math::onehot::onehot_fp::fp16x16;
+use debug::PrintTrait;
+
+/// Cf: TensorTrait::cumsum docstring
+fn onehot(
+    self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, values: Span<usize>
+) -> Option<Tensor<FixedType>> {
+    match *self.extra {
+        Option::Some(extra_params) => match extra_params.fixed_point {
+            Option::Some(fixed_point) => match fixed_point {
+                FixedImpl::FP8x23(()) => Option::Some(
+                    fp8x23::onehot(self, depth, axis, values)
+                ),
+                FixedImpl::FP16x16(()) => Option::Some(
+                    fp16x16::onehot(self, depth, axis, values)
+                ),
+            },
+            Option::None(_) => Option::Some(fp16x16::onehot(self, depth, axis, values)),
+        },
+        Option::None(_) => Option::Some(fp16x16::onehot(self, depth, axis, values)),
+    }
+}

--- a/src/operators/tensor/math/onehot/onehot_fp/fp16x16.cairo
+++ b/src/operators/tensor/math/onehot/onehot_fp/fp16x16.cairo
@@ -1,0 +1,136 @@
+use core::traits::Into;
+use debug::PrintTrait;
+use core::traits::TryInto;
+use core::serde::Serde;
+use core::traits::Destruct;
+use core::clone::Clone;
+use option::OptionTrait;
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+use orion::numbers::fixed_point::implementations::impl_16x16::{
+    FP16x16Impl, FP16x16Add, FP16x16Sub, FP16x16AddEq, FP16x16PartialEq
+};
+use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use array::{ArrayTrait, SpanTrait};
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
+use orion::operators::tensor::implementations::{impl_tensor_i32, impl_tensor_u32};
+use orion::operators::tensor::helpers::replace_index;
+use orion::operators::tensor::implementations::impl_tensor_u32::Tensor_u32;
+
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot_encode( self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, values: Tensor<FixedType> ) -> Tensor<FixedType> {
+    let data = *self.data;
+    let shape = *self.shape;
+    let rank = shape.len();
+
+    // using 999 to denote -1, innermost dimension
+    let axis = match axis {
+        Option::Some(val) =>  val,
+        Option::None(_) => 999
+
+    };
+
+    assert(((axis == 999) | (axis <= rank) ), 'axis out of dimensions');
+
+    let mut tensor_data = self.data.clone();
+    let tensor_len: usize = data.len();
+    
+    let mut output_data = ArrayTrait::new();
+    let mut output_size = ArrayTrait::<u32>::new();
+    let extra = Option::<ExtraParams>::None(());
+
+    // New shape for output data
+    let mut index: usize = 0;
+    loop {
+        if index == shape.len() {
+            break ();
+        };
+        let size: usize = *shape.at(index);
+        output_size.append(size);
+        index += 1;
+    };
+    output_size.append(depth);
+
+    // OneHot enocde loop
+    let mut outer_index: usize = 0;
+    loop {
+        if outer_index == tensor_len {
+            break ();
+        };
+
+        let mut inner_index: usize = 0;
+    
+        let mut fixed_number = *tensor_data.at(outer_index);
+        if fixed_number.sign == true {
+            fixed_number = FP16x16Add::add(FixedTrait::new_unscaled(depth.into(), false), fixed_number)
+        }
+        
+        loop {
+            if inner_index == depth {
+                break ();
+            };
+            let ind = FixedTrait::new_unscaled(inner_index.into(), false);
+
+            if fixed_number == ind {
+                output_data.append(*values.data.at(1));
+            } 
+            else {
+                output_data.append(*values.data.at(0));
+            };
+
+            inner_index += 1;
+        };
+
+        outer_index += 1;
+    };
+
+    let mut output_tensor = TensorTrait::<FixedType>::new(output_size.span(), output_data.span(), extra);
+    let mut tranpose_axes = ArrayTrait::<u32>::new();
+    // Get New shape is axis is not last dimension
+    if (axis != 999) & (axis != rank) {
+        let mut index:usize = 0;
+        loop {
+                let max_dim = output_size.len() - 1;
+                if index ==  max_dim{
+                    break ();
+                };
+
+                if axis == index{
+                    tranpose_axes.append(max_dim)
+                }
+                tranpose_axes.append(index);
+                index += 1;
+            };
+
+        let mut index: usize = 0;
+
+
+        output_tensor = output_tensor.transpose(tranpose_axes.span());
+    }
+
+    return output_tensor;
+
+}
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot(
+    self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, mut values: Span<usize>,
+) -> Tensor<FixedType> {
+
+    assert(values.len() == 2, 'Wrong values dimensions');
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+
+    let mut first = *values.pop_front().unwrap();
+    let mut second = *values.pop_front().unwrap();
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new_unscaled(first.into(), false));
+    data.append(FixedTrait::new_unscaled(second.into(), false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let values = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+    onehot_encode(self, depth, axis, values)
+}

--- a/src/operators/tensor/math/onehot/onehot_fp/fp8x23.cairo
+++ b/src/operators/tensor/math/onehot/onehot_fp/fp8x23.cairo
@@ -1,0 +1,132 @@
+use core::traits::Into;
+use debug::PrintTrait;
+use core::traits::TryInto;
+use core::serde::Serde;
+use core::traits::Destruct;
+use core::clone::Clone;
+use option::OptionTrait;
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+use orion::numbers::fixed_point::implementations::impl_8x23::{
+    FP8x23Impl, FP8x23Add, FP8x23Sub, FP8x23AddEq, FP8x23PartialEq
+};
+use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use array::{ArrayTrait, SpanTrait};
+
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot_encode( self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, values: Tensor<FixedType> ) -> Tensor<FixedType> {
+    let data = *self.data;
+    let shape = *self.shape;
+    let rank = shape.len();
+
+    // using 999 to denote -1, innermost dimension
+    let axis = match axis {
+        Option::Some(val) =>  val,
+        Option::None(_) => 999
+
+    };
+
+    assert(((axis == 999) | (axis <= rank) ), 'axis out of dimensions');
+
+    let mut tensor_data = self.data.clone();
+    let tensor_len: usize = data.len();
+    
+    let mut output_data = ArrayTrait::new();
+    let mut output_size = ArrayTrait::<u32>::new();
+    let extra = Option::<ExtraParams>::None(());
+
+    // New shape for output data
+    let mut index: usize = 0;
+    loop {
+        if index == shape.len() {
+            break ();
+        };
+        let size: usize = *shape.at(index);
+        output_size.append(size);
+        index += 1;
+    };
+    output_size.append(depth);
+
+    // OneHot enocde loop
+    let mut outer_index: usize = 0;
+    loop {
+        if outer_index == tensor_len {
+            break ();
+        };
+
+        let mut inner_index: usize = 0;
+    
+        let mut fixed_number = *tensor_data.at(outer_index);
+        if fixed_number.sign == true {
+            fixed_number = FP8x23Add::add(FixedTrait::new_unscaled(depth.into(), false), fixed_number)
+        }
+        
+        loop {
+            if inner_index == depth {
+                break ();
+            };
+            let ind = FixedTrait::new_unscaled(inner_index.into(), false);
+
+            if fixed_number == ind {
+                output_data.append(*values.data.at(1));
+            } 
+            else {
+                output_data.append(*values.data.at(0));
+            };
+
+            inner_index += 1;
+        };
+
+        outer_index += 1;
+    };
+
+    let mut output_tensor = TensorTrait::<FixedType>::new(output_size.span(), output_data.span(), extra);
+    let mut tranpose_axes = ArrayTrait::<u32>::new();
+    // Get New shape is axis is not last dimension
+    if (axis != 999) & (axis != rank) {
+        let mut index:usize = 0;
+        loop {
+                let max_dim = output_size.len() - 1;
+                if index ==  max_dim{
+                    break ();
+                };
+
+                if axis == index{
+                    tranpose_axes.append(max_dim)
+                }
+                tranpose_axes.append(index);
+                index += 1;
+            };
+
+        let mut index: usize = 0;
+
+
+        output_tensor = output_tensor.transpose(tranpose_axes.span());
+    }
+
+    return output_tensor;
+
+}
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot(
+    self: @Tensor<FixedType>, depth: usize, axis: Option<usize>, mut values: Span<usize>,
+) -> Tensor<FixedType> {
+
+    assert(values.len() == 2, 'Wrong values dimensions');
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+
+    let mut first = *values.pop_front().unwrap();
+    let mut second = *values.pop_front().unwrap();
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new_unscaled(first.into(), false));
+    data.append(FixedTrait::new_unscaled(second.into(), false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let values = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+    onehot_encode(self, depth, axis, values)
+}

--- a/src/operators/tensor/math/onehot/onehot_i32.cairo
+++ b/src/operators/tensor/math/onehot/onehot_i32.cairo
@@ -1,0 +1,142 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+
+use core::traits::Into;
+use debug::PrintTrait;
+use core::traits::TryInto;
+use core::serde::Serde;
+use core::traits::Destruct;
+use core::clone::Clone;
+use option::OptionTrait;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
+use orion::operators::tensor::implementations::impl_tensor_i32::Tensor_i32;
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use orion::numbers::signed_integer::i32::{
+   i32Add, i32AddEq, i32PartialEq, i32PartialOrd, i32_new, i32Into
+};
+
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot_encode( self: @Tensor<i32>, depth: usize, axis: Option<usize>, values: Tensor<i32> ) -> Tensor<i32> {
+    let data = *self.data;
+    let shape = *self.shape;
+    let rank = shape.len();
+
+    // using 255 to denote -1, innermost dimension
+    let axis = match axis {
+        Option::Some(val) =>  val,
+        Option::None(_) => 255
+
+    };
+
+
+    assert(((axis == 255) | (axis.into() <= rank) ), 'axis out of dimensions');
+
+    let mut tensor_data = self.data.clone();
+    let tensor_len: usize = data.len();
+    
+    let mut output_data = ArrayTrait::new();
+    let mut output_size = ArrayTrait::<u32>::new();
+    let extra = Option::<ExtraParams>::None(());
+
+    // New shape for output data
+    let mut index: usize = 0;
+    loop {
+        if index == shape.len() {
+            break ();
+        };
+        let size: usize = *shape.at(index);
+        output_size.append(size);
+        index += 1;
+    };
+    output_size.append(depth.into());
+
+
+    // OneHot enocde loop
+    let mut outer_index: usize = 0;
+    loop {
+        if outer_index == tensor_len {
+            break ();
+        };
+
+        let mut inner_index = 0;
+        let mut fixed_number = *tensor_data.at(outer_index);
+
+        if fixed_number.sign == true {
+            fixed_number = i32Add::add(i32_new(depth, false), fixed_number)
+
+        }
+        
+        loop {
+            if inner_index == depth {
+                break ();
+            };
+            let ind = IntegerTrait::<i32>::new(inner_index, false);
+
+            if fixed_number == ind {
+                output_data.append(*values.data.at(1));
+            } 
+            else {
+                output_data.append(*values.data.at(0));
+            };
+
+            inner_index += 1;
+        };
+
+        outer_index += 1;
+    };
+
+    let mut output_tensor = TensorTrait::<i32>::new(output_size.span(), output_data.span(), extra);
+    let mut tranpose_axes = ArrayTrait::new();
+    // Get New shape is axis is not last dimension
+    if (axis != 255) & (axis.into() != rank) {
+        let mut index: usize = 0;
+        loop {
+                let max_dim = output_size.len() - 1;
+                if index.into() ==  max_dim{
+                    break ();
+                };
+
+                if axis == index {
+                    tranpose_axes.append(max_dim.into())
+                }
+                tranpose_axes.append(index.into());
+                index += 1;
+            };
+
+        let mut index: usize = 0;
+
+
+        output_tensor = output_tensor.transpose(tranpose_axes.span());
+    }
+
+    return output_tensor;
+
+}
+
+
+fn onehot(
+    self: @Tensor<i32>, depth: usize, axis: Option<usize>, mut values: Span<usize>,
+) -> Tensor<i32> {
+
+    assert(values.len() == 2, 'Wrong values dimensions');
+
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+
+    let mut first = *values.pop_front().unwrap();
+    let mut second = *values.pop_front().unwrap();
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::<i32>::new(first, false));
+    data.append(IntegerTrait::<i32>::new(second, false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let values = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+    onehot_encode(self, depth, axis, values)
+    
+}
+
+

--- a/src/operators/tensor/math/onehot/onehot_i8.cairo
+++ b/src/operators/tensor/math/onehot/onehot_i8.cairo
@@ -1,0 +1,148 @@
+use core::traits::Into;
+use debug::PrintTrait;
+use core::traits::TryInto;
+use core::serde::Serde;
+use core::traits::Destruct;
+use core::clone::Clone;
+use option::OptionTrait;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i8::i8};
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+use orion::operators::tensor::implementations::impl_tensor_i8::Tensor_i8;
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use array::{ArrayTrait, SpanTrait};
+use orion::numbers::signed_integer::i8::{
+   i8Add, i8AddEq, i8PartialEq, i8PartialOrd, i8_new, i8Into, 
+};
+
+
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot_encode( self: @Tensor<i8>, depth: usize, axis: Option<usize>, values: Tensor<i8> ) -> Tensor<i8> {
+    let data = *self.data;
+    let shape = *self.shape;
+    let rank = shape.len();
+
+    // using 255 to denote -1, innermost dimension
+    let axis = match axis {
+        Option::Some(val) =>  val,
+        Option::None(_) => 255
+
+    };
+
+
+    assert(((axis == 255) | (axis.into() <= rank) ), 'axis out of dimensions');
+
+    let mut tensor_data = self.data.clone();
+    let tensor_len: usize = data.len();
+    
+    let mut output_data = ArrayTrait::new();
+    let mut output_size = ArrayTrait::<u32>::new();
+    let extra = Option::<ExtraParams>::None(());
+
+    // New shape for output data
+    let mut index: usize = 0;
+    loop {
+        if index == shape.len() {
+            break ();
+        };
+        let size: usize = *shape.at(index);
+        output_size.append(size);
+        index += 1;
+    };
+    output_size.append(depth.into());
+
+
+    // OneHot enocde loop
+    let mut outer_index: usize = 0;
+    loop {
+        if outer_index == tensor_len {
+            break ();
+        };
+
+        let mut inner_index: u8 = 0;
+        let mut fixed_number = *tensor_data.at(outer_index);
+        let depth: u8 = integer::u8_try_from_felt252(integer::u32_to_felt252(depth)).unwrap();
+
+        if fixed_number.sign == true {
+            fixed_number = i8Add::add(i8_new(depth, false), fixed_number)
+
+        }
+        
+        loop {
+            if inner_index == depth {
+                break ();
+            };
+            let ind = IntegerTrait::<i8>::new(inner_index, false);
+
+            if fixed_number == ind {
+                output_data.append(*values.data.at(1));
+            } 
+            else {
+                output_data.append(*values.data.at(0));
+            };
+
+            inner_index += 1;
+        };
+
+        outer_index += 1;
+    };
+
+    let mut output_tensor = TensorTrait::<i8>::new(output_size.span(), output_data.span(), extra);
+    let mut tranpose_axes = ArrayTrait::new();
+    // Get New shape is axis is not last dimension
+    if (axis != 255) & (axis.into() != rank) {
+        let mut index: usize = 0;
+        loop {
+                let max_dim = output_size.len() - 1;
+                if index.into() ==  max_dim{
+                    break ();
+                };
+
+                if axis == index {
+                    tranpose_axes.append(max_dim.into())
+                }
+                tranpose_axes.append(index.into());
+                index += 1;
+            };
+
+        let mut index: usize = 0;
+
+
+        output_tensor = output_tensor.transpose(tranpose_axes.span());
+    }
+
+    return output_tensor;
+
+}
+
+
+fn onehot(
+    self: @Tensor<i8>, depth: usize, axis: Option<usize>, mut values: Span<usize>,
+) -> Tensor<i8> {
+
+    assert(values.len() == 2, 'Wrong values dimensions');
+
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+
+    let mut first = *values.pop_front().unwrap();
+    let mut second = *values.pop_front().unwrap();
+
+
+    let first = integer::u32_to_felt252(first);
+    let second = integer::u32_to_felt252(second);
+    let first: u8 = integer::u8_try_from_felt252(first).unwrap();
+    let second: u8 = integer::u8_try_from_felt252(second).unwrap();
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::<i8>::new(first, false));
+    data.append(IntegerTrait::<i8>::new(second, false));
+    let extra = Option::<ExtraParams>::None(());
+
+    let values = TensorTrait::<i8>::new(sizes.span(), data.span(), extra);
+    onehot_encode(self, depth, axis, values)
+    
+}
+
+

--- a/src/operators/tensor/math/onehot/onehot_u32.cairo
+++ b/src/operators/tensor/math/onehot/onehot_u32.cairo
@@ -1,0 +1,136 @@
+use core::traits::Into;
+use debug::PrintTrait;
+use core::traits::TryInto;
+use core::serde::Serde;
+use core::traits::Destruct;
+use core::clone::Clone;
+use option::OptionTrait;
+use orion::numbers::signed_integer::{integer_trait::IntegerTrait};
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+use orion::operators::tensor::implementations::impl_tensor_u32::Tensor_u32;
+use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+use array::{ArrayTrait, SpanTrait};
+
+
+/// Cf: TensorTrait::onehot docstring
+fn onehot_encode( self: @Tensor<u32>, depth: usize, axis: Option<usize>, values: Tensor<u32> ) -> Tensor<u32> {
+    let data = *self.data;
+    let shape = *self.shape;
+    let rank = shape.len();
+    
+    // using 999 to denote -1, innermost dimension
+    let axis = match axis {
+        Option::Some(val) =>  val,
+        Option::None(_) => 999
+
+    };
+
+    assert(((axis == 999) | (axis.into() <= rank) ), 'axis out of dimensions');
+
+    let mut tensor_data = self.data.clone();
+    let tensor_len: usize = data.len();
+    
+    let mut output_data = ArrayTrait::new();
+    let mut output_size = ArrayTrait::<u32>::new();
+    let extra = Option::<ExtraParams>::None(());
+
+    // New shape for output data
+    let mut index: usize = 0;
+    loop {
+        if index == shape.len() {
+            break ();
+        };
+        let size: usize = *shape.at(index);
+        output_size.append(size);
+        index += 1;
+    };
+    output_size.append(depth.into());
+
+
+
+    // OneHot enocde loop
+    let mut outer_index: usize = 0;
+    loop {
+        if outer_index == tensor_len {
+            break ();
+        };
+
+        let mut inner_index: usize = 0;
+        let mut fixed_number = *tensor_data.at(outer_index);
+        
+        loop {
+            if inner_index == depth {
+                break ();
+            };
+            let ind = inner_index;
+
+
+            if fixed_number == ind {
+                output_data.append(*values.data.at(1));
+            } 
+            else {
+                output_data.append(*values.data.at(0));
+            };
+
+            inner_index += 1;
+        };
+
+        outer_index += 1;
+    };
+
+
+    let mut output_tensor = TensorTrait::<u32>::new(output_size.span(), output_data.span(), extra);
+    let mut tranpose_axes = ArrayTrait::new();
+    // Get New shape is axis is not last dimension
+    if (axis != 999) & (axis.into() != rank) {
+        let mut index: usize = 0;
+        loop {
+                let max_dim = output_size.len() - 1;
+                if index.into() ==  max_dim{
+                    break ();
+                };
+
+                if axis == index {
+                    tranpose_axes.append(max_dim.into())
+                }
+                tranpose_axes.append(index.into());
+                index += 1;
+            };
+
+        let mut index: usize = 0;
+
+
+        output_tensor = output_tensor.transpose(tranpose_axes.span());
+    }
+
+    return output_tensor;
+
+}
+
+
+fn onehot(
+    self: @Tensor<u32>, depth: usize, axis: Option<usize>, mut values: Span<usize>,
+) -> Tensor<u32> {
+
+    assert(values.len() == 2, 'Wrong values dimensions');
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+
+    let mut first: u32 = *values.pop_front().unwrap();
+    let mut second: u32 = *values.pop_front().unwrap();
+
+    let mut data = ArrayTrait::new();
+    data.append(first);
+    data.append(second);
+
+    let extra = Option::<ExtraParams>::None(());
+
+    let values = TensorTrait::<u32>::new(sizes.span(), data.span(), extra);
+
+    onehot_encode(self, depth, axis, values)
+
+    
+}
+
+

--- a/src/tests/operators/tensor/math.cairo
+++ b/src/tests/operators/tensor/math.cairo
@@ -25,4 +25,4 @@ mod acosh;
 mod asinh;
 mod atan;
 mod acos;
-
+mod onehot;

--- a/src/tests/operators/tensor/math/onehot.cairo
+++ b/src/tests/operators/tensor/math/onehot.cairo
@@ -1,0 +1,4 @@
+mod onehot_u32_test;
+mod onehot_i32_test;
+mod onehot_i8_test;
+mod onehot_fp_test;

--- a/src/tests/operators/tensor/math/onehot/onehot_fp_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_fp_test.cairo
@@ -1,0 +1,3 @@
+mod onehot_fp8x23_test;
+mod onehot_fp16x16_test;
+

--- a/src/tests/operators/tensor/math/onehot/onehot_fp_test/onehot_fp16x16_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_fp_test/onehot_fp16x16_test.cairo
@@ -1,0 +1,534 @@
+use core::serde::Serde;
+use core::option::OptionTrait;
+use core::clone::Clone;
+// ===== 1D ===== //
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+
+#[cfg(test)]
+mod tensor_1D {
+    use array::{ArrayTrait, SpanTrait};
+    use core::traits::Into;
+    use orion::numbers::fixed_point::core::{FixedTrait, FixedType, FixedImpl};
+    use orion::numbers::fixed_point::implementations::impl_16x16::{
+        FP16x16Impl, FP16x16Into, FP16x16PartialEq
+    };
+    use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+    use orion::tests::helpers::tensor::fixed_point::fp16x16::{
+        fp_tensor_1x3_helper, fp_tensor_2x2_helper, fp_tensor_3x2x2_neg_helper, fp_tensor_1x3_neg_helper, fp_tensor_2x2x2_helper
+    };
+    use orion::operators::tensor::core::TensorTrait;
+    use debug::PrintTrait;
+    use core::clone::Clone;
+    use core::option::OptionTrait;
+    use serde::Serde;
+
+    // use orion::numbers::fixed_point::implementations::impl_16x16::FP16x16Impl;
+    // use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+    use orion::operators::tensor::core::{Tensor, ExtraParams};
+
+    fn fp_tensor_3x2x2_new() -> Tensor<FixedType> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(3);
+        sizes.append(2);
+        sizes.append(2);
+
+        let mut data = ArrayTrait::new();
+        data.append(FixedTrait::new_unscaled(0, false));
+        data.append(FixedTrait::new_unscaled(1, false));
+        data.append(FixedTrait::new_unscaled(2, false));
+        data.append(FixedTrait::new_unscaled(3, false));
+        data.append(FixedTrait::new_unscaled(0, false));
+        data.append(FixedTrait::new_unscaled(1, false));
+        data.append(FixedTrait::new_unscaled(2, false));
+        data.append(FixedTrait::new_unscaled(3, false));
+        data.append(FixedTrait::new_unscaled(0, false));
+        data.append(FixedTrait::new_unscaled(1, false));
+        data.append(FixedTrait::new_unscaled(2, false));
+        data.append(FixedTrait::new_unscaled(3, false));
+
+        let extra = Option::<ExtraParams>::None(());
+
+        let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+
+        return tensor;
+}
+
+    fn fp_tensor_2x2_pos_neg_new() -> Tensor<FixedType> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(2);
+        sizes.append(2);
+
+        let mut data = ArrayTrait::new();
+        data.append(FixedTrait::new_unscaled(0, false));
+        data.append(FixedTrait::new_unscaled(1, false));
+        data.append(FixedTrait::new_unscaled(2, true));
+        data.append(FixedTrait::new_unscaled(1, true));
+
+        let extra = Option::<ExtraParams>::None(());
+
+        let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), extra);
+
+        return tensor;
+}
+
+
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_last_axis() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_neg_last_axis() {
+        let tensor = fp_tensor_1x3_neg_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(1, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_2x2_post_neg_last_axis() {
+        let tensor = fp_tensor_2x2_pos_neg_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(1, false), 'result[7] = 1');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(0, false), 'result[10] = 0');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(1, false), 'result[11] = 0');
+
+        }
+
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_1x3_fail() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+    
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_Zero_axis() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+         assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_axis_one() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_last_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[0] = 4');
+
+        }
+
+     #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_2x2_fail() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_first_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_second_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(1, false), 'result[3] = 1');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(0, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(1, false), 'result[12] = 1');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_last_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+        // let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(1, false), 'result[21] = 1');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(1, false), 'result[26] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(1, false), 'result[37] = 1');
+        assert((*result.data[42]) == FixedTrait::new_unscaled(1, false), 'result[42] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 2');
+        assert((*result.shape.at(3)) == 4, 'shape[0] = 4');
+        }
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_3x2x2_fail() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(4);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_first_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(2);
+        values.append(5);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(5, false), 'result[0] = 5');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(2, false), 'result[1] = 2');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(2, false), 'result[2] = 2');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(2, false), 'result[3] = 2');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(5, false), 'result[4] = 5');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(2, false), 'result[5] = 2');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(2, false), 'result[6] = 2');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(2, false), 'result[7] = 2');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(5, false), 'result[8] = 5');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(2, false), 'result[9] = 2');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(2, false), 'result[10] = 2');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(2, false), 'result[11] = 2');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(2, false), 'result[12] = 2');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(5, false), 'result[13] = 5');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(2, false), 'result[14] = 2');
+        assert((*result.data[17]) == FixedTrait::new_unscaled(5, false), 'result[17] = 5');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(5, false), 'result[21] = 5');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(5, false), 'result[26] = 5');
+        assert((*result.data[30]) == FixedTrait::new_unscaled(5, false), 'result[30] = 5');
+        assert((*result.data[34]) == FixedTrait::new_unscaled(5, false), 'result[34] = 5');
+        assert((*result.data[39]) == FixedTrait::new_unscaled(5, false), 'result[39] = 5');
+        assert((*result.data[43]) == FixedTrait::new_unscaled(5, false), 'result[43] = 5');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(2, false), 'result[46] = 2');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(5, false), 'result[47] = 5');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 3, 'shape[1] = 3');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_second_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(1, false), 'result[21] = 1');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(1, false), 'result[26] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(1, false), 'result[37] = 1');
+        assert((*result.data[42]) == FixedTrait::new_unscaled(1, false), 'result[42] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 4, 'shape[1] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_third_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(2);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(1, false), 'result[3] = 1');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(1, false), 'result[12] = 1');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[19]) == FixedTrait::new_unscaled(1, false), 'result[19] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(0, false), 'result[21] = 0');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(0, false), 'result[26] = 0');
+        assert((*result.data[28]) == FixedTrait::new_unscaled(1, false), 'result[28] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[35]) == FixedTrait::new_unscaled(1, false), 'result[35] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(0, false), 'result[37] = 0');
+        assert((*result.data[44]) == FixedTrait::new_unscaled(1, false), 'result[44] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[2] = 4');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    
+}
+

--- a/src/tests/operators/tensor/math/onehot/onehot_fp_test/onehot_fp8x23_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_fp_test/onehot_fp8x23_test.cairo
@@ -1,0 +1,530 @@
+use core::serde::Serde;
+use core::option::OptionTrait;
+use core::clone::Clone;
+// ===== 1D ===== //
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+
+#[cfg(test)]
+mod tensor_1D {
+    use array::{ArrayTrait, SpanTrait};
+    use core::traits::Into;
+    use orion::numbers::fixed_point::core::{FixedTrait, FixedType, FixedImpl};
+    use orion::numbers::fixed_point::implementations::impl_8x23::{
+        FP8x23Impl, FP8x23Into, FP8x23PartialEq
+    };
+    use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+    use orion::operators::tensor::core::TensorTrait;
+    use orion::tests::helpers::tensor::fixed_point::fp8x23::{
+        fp_tensor_1x3_helper, fp_tensor_2x2_helper, fp_tensor_3x2x2_neg_helper, fp_tensor_1x3_neg_helper, fp_tensor_2x2x2_helper
+    };
+    use debug::PrintTrait;
+    use core::clone::Clone;
+    use core::option::OptionTrait;
+    use serde::Serde;
+
+    use orion::operators::tensor::core::{Tensor, ExtraParams};
+
+    fn fp_tensor_3x2x2_new() -> Tensor<FixedType> {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(2);
+    sizes.append(2);
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new_unscaled(0, false));
+    data.append(FixedTrait::new_unscaled(1, false));
+    data.append(FixedTrait::new_unscaled(2, false));
+    data.append(FixedTrait::new_unscaled(3, false));
+    data.append(FixedTrait::new_unscaled(0, false));
+    data.append(FixedTrait::new_unscaled(1, false));
+    data.append(FixedTrait::new_unscaled(2, false));
+    data.append(FixedTrait::new_unscaled(3, false));
+    data.append(FixedTrait::new_unscaled(0, false));
+    data.append(FixedTrait::new_unscaled(1, false));
+    data.append(FixedTrait::new_unscaled(2, false));
+    data.append(FixedTrait::new_unscaled(3, false));
+
+    let extra = ExtraParams { fixed_point: Option::Some(FixedImpl::FP8x23(())) };
+    let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), Option::Some(extra));
+    
+    return tensor;
+}
+
+    fn fp_tensor_2x2_pos_neg_new() -> Tensor<FixedType> {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+    sizes.append(2);
+
+    let mut data = ArrayTrait::new();
+    data.append(FixedTrait::new_unscaled(0, false));
+    data.append(FixedTrait::new_unscaled(1, false));
+    data.append(FixedTrait::new_unscaled(2, true));
+    data.append(FixedTrait::new_unscaled(1, true));
+
+    let extra = ExtraParams { fixed_point: Option::Some(FixedImpl::FP8x23(())) };
+    let tensor = TensorTrait::<FixedType>::new(sizes.span(), data.span(), Option::Some(extra));
+
+    return tensor;
+}
+
+
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_last_axis() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_neg_last_axis() {
+        let tensor = fp_tensor_1x3_neg_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(1, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_2x2_post_neg_last_axis() {
+        let tensor = fp_tensor_2x2_pos_neg_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(1, false), 'result[7] = 1');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(0, false), 'result[10] = 0');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(1, false), 'result[11] = 0');
+
+        }
+
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_1x3_fail() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+    
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_Zero_axis() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+         assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_axis_one() {
+        let tensor = fp_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(1, false), 'result[4] = 1');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(1, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_last_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[0] = 4');
+
+        }
+
+     #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_2x2_fail() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_first_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_second_axis() {
+        let tensor = fp_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(1, false), 'result[3] = 1');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(0, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(1, false), 'result[12] = 1');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_last_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+        // let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(1, false), 'result[21] = 1');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(1, false), 'result[26] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(1, false), 'result[37] = 1');
+        assert((*result.data[42]) == FixedTrait::new_unscaled(1, false), 'result[42] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 2');
+        assert((*result.shape.at(3)) == 4, 'shape[0] = 4');
+        }
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_3x2x2_fail() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(4);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_first_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(2);
+        values.append(5);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(5, false), 'result[0] = 5');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(2, false), 'result[1] = 2');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(2, false), 'result[2] = 2');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(2, false), 'result[3] = 2');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(5, false), 'result[4] = 5');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(2, false), 'result[5] = 2');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(2, false), 'result[6] = 2');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(2, false), 'result[7] = 2');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(5, false), 'result[8] = 5');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(2, false), 'result[9] = 2');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(2, false), 'result[10] = 2');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(2, false), 'result[11] = 2');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(2, false), 'result[12] = 2');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(5, false), 'result[13] = 5');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(2, false), 'result[14] = 2');
+        assert((*result.data[17]) == FixedTrait::new_unscaled(5, false), 'result[17] = 5');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(5, false), 'result[21] = 5');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(5, false), 'result[26] = 5');
+        assert((*result.data[30]) == FixedTrait::new_unscaled(5, false), 'result[30] = 5');
+        assert((*result.data[34]) == FixedTrait::new_unscaled(5, false), 'result[34] = 5');
+        assert((*result.data[39]) == FixedTrait::new_unscaled(5, false), 'result[39] = 5');
+        assert((*result.data[43]) == FixedTrait::new_unscaled(5, false), 'result[43] = 5');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(2, false), 'result[46] = 2');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(5, false), 'result[47] = 5');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 3, 'shape[1] = 3');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_second_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(0, false), 'result[3] = 0');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(1, false), 'result[5] = 1');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[7]) == FixedTrait::new_unscaled(0, false), 'result[7] = 0');
+        assert((*result.data[8]) == FixedTrait::new_unscaled(0, false), 'result[8] = 0');
+        assert((*result.data[9]) == FixedTrait::new_unscaled(0, false), 'result[9] = 0');
+        assert((*result.data[10]) == FixedTrait::new_unscaled(1, false), 'result[10] = 1');
+        assert((*result.data[11]) == FixedTrait::new_unscaled(0, false), 'result[11] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(0, false), 'result[12] = 0');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(1, false), 'result[21] = 1');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(1, false), 'result[26] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(1, false), 'result[37] = 1');
+        assert((*result.data[42]) == FixedTrait::new_unscaled(1, false), 'result[42] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 4, 'shape[1] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_third_axis() {
+        let tensor = fp_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(2);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == FixedTrait::new_unscaled(1, false), 'result[0] = 1');
+        assert((*result.data[1]) == FixedTrait::new_unscaled(0, false), 'result[1] = 0');
+        assert((*result.data[2]) == FixedTrait::new_unscaled(0, false), 'result[2] = 0');
+        assert((*result.data[3]) == FixedTrait::new_unscaled(1, false), 'result[3] = 1');
+        assert((*result.data[4]) == FixedTrait::new_unscaled(0, false), 'result[4] = 0');
+        assert((*result.data[5]) == FixedTrait::new_unscaled(0, false), 'result[5] = 0');
+        assert((*result.data[6]) == FixedTrait::new_unscaled(0, false), 'result[6] = 0');
+        assert((*result.data[12]) == FixedTrait::new_unscaled(1, false), 'result[12] = 1');
+        assert((*result.data[13]) == FixedTrait::new_unscaled(0, false), 'result[13] = 0');
+        assert((*result.data[14]) == FixedTrait::new_unscaled(0, false), 'result[14] = 0');
+        assert((*result.data[15]) == FixedTrait::new_unscaled(1, false), 'result[15] = 1');
+        assert((*result.data[16]) == FixedTrait::new_unscaled(1, false), 'result[16] = 1');
+        assert((*result.data[19]) == FixedTrait::new_unscaled(1, false), 'result[19] = 1');
+        assert((*result.data[21]) == FixedTrait::new_unscaled(0, false), 'result[21] = 0');
+        assert((*result.data[26]) == FixedTrait::new_unscaled(0, false), 'result[26] = 0');
+        assert((*result.data[28]) == FixedTrait::new_unscaled(1, false), 'result[28] = 1');
+        assert((*result.data[31]) == FixedTrait::new_unscaled(1, false), 'result[31] = 1');
+        assert((*result.data[32]) == FixedTrait::new_unscaled(1, false), 'result[32] = 1');
+        assert((*result.data[35]) == FixedTrait::new_unscaled(1, false), 'result[35] = 1');
+        assert((*result.data[37]) == FixedTrait::new_unscaled(0, false), 'result[37] = 0');
+        assert((*result.data[44]) == FixedTrait::new_unscaled(1, false), 'result[44] = 1');
+        assert((*result.data[46]) == FixedTrait::new_unscaled(0, false), 'result[46] = 0');
+        assert((*result.data[47]) == FixedTrait::new_unscaled(1, false), 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[2] = 4');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    
+}
+

--- a/src/tests/operators/tensor/math/onehot/onehot_i32_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_i32_test.cairo
@@ -1,0 +1,512 @@
+
+use core::serde::Serde;
+use core::option::OptionTrait;
+use core::clone::Clone;
+// ===== 1D ===== //
+
+
+#[cfg(test)]
+mod tensor_1D {
+    use array::{ArrayTrait, SpanTrait};
+    use core::traits::Into;
+    use orion::numbers::fixed_point::core::{FixedTrait, FixedImpl};
+    use orion::numbers::fixed_point::implementations::impl_16x16::{
+        FP16x16Impl, FP16x16Into, FP16x16PartialEq
+    };
+    use debug::PrintTrait;
+    use core::clone::Clone;
+    use core::option::OptionTrait;
+    use serde::Serde;
+    use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i32::i32};
+    use orion::operators::tensor::implementations::impl_tensor_i32::Tensor_i32;
+    use orion::operators::tensor::core::{TensorTrait, Tensor, ExtraParams};
+
+    use orion::tests::helpers::tensor::i32::{i32_tensor_1x3_helper, i32_tensor_1x3_neg_helper, i32_tensor_2x2_helper, i32_tensor_3x2x2_helper};
+
+
+    fn i32_tensor_3x2x2_new() -> Tensor<i32> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(3);
+        sizes.append(2);
+        sizes.append(2);
+
+        let mut data = ArrayTrait::new();
+        data.append(i32 {mag: 0, sign: false});
+        data.append(i32 {mag: 1, sign: false});
+        data.append(i32 {mag: 2, sign: false});
+        data.append(i32 {mag: 3, sign: false});
+        data.append(i32 {mag: 0, sign: false});
+        data.append(i32 {mag: 1, sign: false});
+        data.append(i32 {mag: 2, sign: false});
+        data.append(i32 {mag: 3, sign: false});
+        data.append(i32 {mag: 0, sign: false});
+        data.append(i32 {mag: 1, sign: false});
+        data.append(i32 {mag: 2, sign: false});
+        data.append(i32 {mag: 3, sign: false});
+
+        let extra = Option::<ExtraParams>::None(());
+
+        let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+
+        return tensor;
+}
+
+    fn i32_tensor_2x2_pos_neg_new() -> Tensor<i32> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(2);
+        sizes.append(2);
+
+        let mut data = ArrayTrait::new();
+        data.append(i32 {mag: 0, sign: false});
+        data.append(i32 {mag: 1, sign: false});
+        data.append(i32 {mag: 2, sign: true});
+        data.append(i32 {mag: 1, sign: true});
+
+        let extra = Option::<ExtraParams>::None(());
+
+        let tensor = TensorTrait::<i32>::new(sizes.span(), data.span(), extra);
+
+        return tensor;
+}
+
+
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_last_axis() {
+        let tensor = i32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 1, 'result[4] = 1');
+        assert((*result.data.at(5)).into() == 0, 'result[5] = 0');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0, 'result[7] = 0');
+        assert((*result.data.at(8)).into() == 1, 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_neg_last_axis() {
+        let tensor = i32_tensor_1x3_neg_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+         assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 0, 'result[4] = 0');
+        assert((*result.data.at(5)).into() == 1, 'result[5] = 1');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 1, 'result[7] = 1');
+        assert((*result.data.at(8)).into() == 0, 'result[8] = 0');
+        }
+
+        #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_1x3_fail() {
+        let tensor = i32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+    
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_Zero_axis() {
+        let tensor = i32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 1, 'result[4] = 1');
+        assert((*result.data.at(5)).into() == 0, 'result[5] = 0');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0, 'result[7] = 0');
+        assert((*result.data.at(8)).into() == 1, 'result[8] = 1');
+        }
+
+       #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_2x2_post_neg_last_axis() {
+        let tensor = i32_tensor_2x2_pos_neg_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 1, 'result[4] = 1');
+        assert((*result.data.at(5)).into() == 0, 'result[5] = 0');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 1, 'result[7] = 1');
+        assert((*result.data.at(8)).into() == 0, 'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0, 'result[9] = 0');
+        assert((*result.data.at(10)).into() == 0, 'result[10] = 0');
+        assert((*result.data.at(11)).into() == 1, 'result[11] = 1');
+
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_last_axis() {
+        let tensor = i32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1,'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0,'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0,'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0,'result[3] = 0');
+        assert((*result.data.at(4)).into() == 0,'result[4] = 0');
+        assert((*result.data.at(5)).into() == 1,'result[5] = 1');
+        assert((*result.data.at(6)).into() == 0,'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0,'result[7] = 0');
+        assert((*result.data.at(8)).into() == 0,'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0,'result[9] = 0');
+        assert((*result.data.at(10)).into() == 1, 'result[10] = 1');
+        assert((*result.data.at(11)).into() == 0, 'result[11] = 0');
+        assert((*result.data.at(12)).into() == 0, 'result[12] = 0');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[0] = 4');
+
+        }
+
+     #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_2x2_fail() {
+        let tensor = i32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_first_axis() {
+        let tensor = i32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1,'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0,'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0,'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0,'result[3] = 0');
+        assert((*result.data.at(4)).into() == 0,'result[4] = 0');
+        assert((*result.data.at(5)).into() == 1,'result[5] = 1');
+        assert((*result.data.at(6)).into() == 0,'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0,'result[7] = 0');
+        assert((*result.data.at(8)).into() == 0,'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0,'result[9] = 0');
+        assert((*result.data.at(10)).into() == 1, 'result[10] = 1');
+        assert((*result.data.at(11)).into() == 0, 'result[11] = 0');
+        assert((*result.data.at(12)).into() == 0, 'result[12] = 0');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_second_axis() {
+        let tensor = i32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+         assert((*result.data.at(0)).into() == 1,'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0,'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0,'result[2] = 0');
+        assert((*result.data.at(3)).into() == 1,'result[3] = 1');
+        assert((*result.data.at(4)).into() == 0,'result[4] = 0');
+        assert((*result.data.at(5)).into() == 0,'result[5] = 0');
+        assert((*result.data.at(6)).into() == 0,'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0,'result[7] = 0');
+        assert((*result.data.at(8)).into() == 0,'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0,'result[9] = 0');
+        assert((*result.data.at(10)).into() == 0, 'result[10] = 0');
+        assert((*result.data.at(11)).into() == 0, 'result[11] = 0');
+        assert((*result.data.at(12)).into() == 1, 'result[12] = 0');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+
+
+
+
+
+         #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_last_axis() {
+        let tensor = i32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 0, 'result[4] = 0');
+        assert((*result.data.at(5)).into() == 1, 'result[5] = 1');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0, 'result[7] = 0');
+        assert((*result.data.at(8)).into() == 0, 'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0, 'result[9] = 0');
+        assert((*result.data.at(10)).into() == 1, 'result[10] = 1');
+        assert((*result.data.at(11)).into() == 0, 'result[11] = 0');
+        assert((*result.data.at(12)).into() == 0, 'result[12] = 0');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+        assert((*result.data.at(16)).into() == 1, 'result[16] = 1');
+        assert((*result.data.at(21)).into() == 1, 'result[21] = 1');
+        assert((*result.data.at(26)).into() == 1, 'result[26] = 1');
+        assert((*result.data.at(31)).into() == 1, 'result[31] = 1');
+        assert((*result.data.at(32)).into() == 1, 'result[32] = 1');
+        assert((*result.data.at(37)).into() == 1, 'result[37] = 1');
+        assert((*result.data.at(42)).into() == 1, 'result[42] = 1');
+        assert((*result.data.at(46)).into() == 0, 'result[46] = 0');
+        assert((*result.data.at(47)).into() == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 2');
+        assert((*result.shape.at(3)) == 4, 'shape[0] = 4');
+        }
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_3x2x2_fail() {
+        let tensor = i32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(4);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_first_axis() {
+        let tensor = i32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(2);
+        values.append(5);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 5, 'result[0] = 5');
+        assert((*result.data.at(1)).into() == 2, 'result[1] = 2');
+        assert((*result.data.at(2)).into() == 2, 'result[2] = 2');
+        assert((*result.data.at(3)).into() == 2, 'result[3] = 2');
+        assert((*result.data.at(4)).into() == 5, 'result[4] = 5');
+        assert((*result.data.at(5)).into() == 2, 'result[5] = 2');
+        assert((*result.data.at(6)).into() == 2, 'result[6] = 2');
+        assert((*result.data.at(7)).into() == 2, 'result[7] = 2');
+        assert((*result.data.at(8)).into() == 5, 'result[8] = 5');
+        assert((*result.data.at(9)).into() == 2, 'result[9] = 2');
+        assert((*result.data.at(10)).into() == 2, 'result[10] = 2');
+        assert((*result.data.at(11)).into() == 2, 'result[11] = 2');
+        assert((*result.data.at(12)).into() == 2, 'result[12] = 2');
+        assert((*result.data.at(13)).into() == 5, 'result[13] = 5');
+        assert((*result.data.at(14)).into() == 2, 'result[14] = 2');
+        assert((*result.data.at(17)).into() == 5, 'result[17] = 5');
+        assert((*result.data.at(21)).into() == 5, 'result[21] = 5');
+        assert((*result.data.at(26)).into() == 5, 'result[26] = 5');
+        assert((*result.data.at(30)).into() == 5, 'result[30] = 5');
+        assert((*result.data.at(34)).into() == 5, 'result[34] = 5');
+        assert((*result.data.at(39)).into() == 5, 'result[39] = 5');
+        assert((*result.data.at(43)).into() == 5, 'result[43] = 5');
+        assert((*result.data.at(46)).into() == 2, 'result[46] = 2');
+        assert((*result.data.at(47)).into() == 5, 'result[47] = 5');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 3, 'shape[1] = 3');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_second_axis() {
+        let tensor = i32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 0, 'result[3] = 0');
+        assert((*result.data.at(4)).into() == 0, 'result[4] = 0');
+        assert((*result.data.at(5)).into() == 1, 'result[5] = 1');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(7)).into() == 0, 'result[7] = 0');
+        assert((*result.data.at(8)).into() == 0, 'result[8] = 0');
+        assert((*result.data.at(9)).into() == 0, 'result[9] = 0');
+        assert((*result.data.at(10)).into() == 1, 'result[10] = 1');
+        assert((*result.data.at(11)).into() == 0, 'result[11] = 0');
+        assert((*result.data.at(12)).into() == 0, 'result[12] = 0');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+        assert((*result.data.at(16)).into() == 1, 'result[16] = 1');
+        assert((*result.data.at(21)).into() == 1, 'result[21] = 1');
+        assert((*result.data.at(26)).into() == 1, 'result[26] = 1');
+        assert((*result.data.at(31)).into() == 1, 'result[31] = 1');
+        assert((*result.data.at(32)).into() == 1, 'result[32] = 1');
+        assert((*result.data.at(37)).into() == 1, 'result[37] = 1');
+        assert((*result.data.at(42)).into() == 1, 'result[42] = 1');
+        assert((*result.data.at(46)).into() == 0, 'result[46] = 0');
+        assert((*result.data.at(47)).into() == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 4, 'shape[1] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_third_axis() {
+        let tensor = i32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(2);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)).into() == 1, 'result[0] = 1');
+        assert((*result.data.at(1)).into() == 0, 'result[1] = 0');
+        assert((*result.data.at(2)).into() == 0, 'result[2] = 0');
+        assert((*result.data.at(3)).into() == 1, 'result[3] = 1');
+        assert((*result.data.at(4)).into() == 0, 'result[4] = 0');
+        assert((*result.data.at(5)).into() == 0, 'result[5] = 0');
+        assert((*result.data.at(6)).into() == 0, 'result[6] = 0');
+        assert((*result.data.at(12)).into() == 1, 'result[12] = 1');
+        assert((*result.data.at(13)).into() == 0, 'result[13] = 0');
+        assert((*result.data.at(14)).into() == 0, 'result[14] = 0');
+        assert((*result.data.at(15)).into() == 1, 'result[15] = 1');
+        assert((*result.data.at(16)).into() == 1, 'result[16] = 1');
+        assert((*result.data.at(19)).into() == 1, 'result[19] = 1');
+        assert((*result.data.at(21)).into() == 0, 'result[21] = 0');
+        assert((*result.data.at(26)).into() == 0, 'result[26] = 0');
+        assert((*result.data.at(28)).into() == 1, 'result[28] = 1');
+        assert((*result.data.at(31)).into() == 1, 'result[31] = 1');
+        assert((*result.data.at(32)).into() == 1, 'result[32] = 1');
+        assert((*result.data.at(35)).into() == 1, 'result[35] = 1');
+        assert((*result.data.at(37)).into() == 0, 'result[37] = 0');
+        assert((*result.data.at(44)).into() == 1, 'result[44] = 1');
+        assert((*result.data.at(46)).into() == 0, 'result[46] = 0');
+        assert((*result.data.at(47)).into() == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[2] = 4');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+
+
+
+}

--- a/src/tests/operators/tensor/math/onehot/onehot_i8_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_i8_test.cairo
@@ -1,0 +1,149 @@
+
+use core::serde::Serde;
+use core::option::OptionTrait;
+use core::clone::Clone;
+// ===== 1D ===== //
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+
+#[cfg(test)]
+mod tensor_1D {
+    use array::{ArrayTrait, SpanTrait};
+    use core::traits::Into;
+    use orion::numbers::fixed_point::core::{FixedTrait, FixedType, FixedImpl};
+    use orion::numbers::fixed_point::implementations::impl_16x16::{
+        FP16x16Impl, FP16x16Into, FP16x16PartialEq
+    };
+    use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+    use orion::tests::helpers::tensor::fixed_point::fp16x16::{
+        fp_tensor_1x3_helper, fp_tensor_2x2_helper, fp_tensor_3x2x2_neg_helper, fp_tensor_1x3_neg_helper, fp_tensor_2x2x2_helper
+    };
+    use orion::operators::tensor::core::TensorTrait;
+    use debug::PrintTrait;
+    use core::clone::Clone;
+    use core::option::OptionTrait;
+    use serde::Serde;
+
+
+    use orion::operators::tensor::implementations::impl_tensor_i8::Tensor_i8;
+
+    // use orion::numbers::fixed_point::implementations::impl_16x16::FP16x16Impl;
+    // use orion::operators::tensor::implementations::impl_tensor_fp::Tensor_fp;
+    use orion::operators::tensor::core::{Tensor, ExtraParams};
+
+
+    use orion::numbers::signed_integer::{integer_trait::IntegerTrait, i8::i8};
+
+
+    // 1D
+    fn i8_tensor_1x3_helper() -> Tensor<i8> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(3);
+        let mut data = ArrayTrait::new();
+        data.append(i8 { mag: 0, sign: false });
+        data.append(i8 { mag: 1, sign: false });
+        data.append(i8 { mag: 2, sign: false });
+        let extra = Option::<ExtraParams>::None(());
+        let tensor = TensorTrait::<i8>::new(sizes.span(), data.span(), extra);
+        return tensor;
+    }
+
+    fn i8_tensor_1x3_neg_helper() -> Tensor<i8> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(3);
+        let mut data = ArrayTrait::new();
+        data.append(i8 { mag: 0, sign: false });
+        data.append(i8 { mag: 1, sign: true });
+        data.append(i8 { mag: 2, sign: true });
+        let extra = Option::<ExtraParams>::None(());
+        let tensor = TensorTrait::<i8>::new(sizes.span(), data.span(), extra);
+        return tensor;
+    }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_last_axis() {
+        let tensor = i8_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)) == IntegerTrait::new(1, false), 'result[0] = 1');
+        assert((*result.data.at(1)) == IntegerTrait::new(0, false), 'result[1] = 0');
+        assert((*result.data.at(2)) == IntegerTrait::new(0, false), 'result[2] = 0');
+        assert((*result.data.at(3)) == IntegerTrait::new(0, false), 'result[3] = 0');
+        assert((*result.data.at(4)) == IntegerTrait::new(1, false), 'result[4] = 1');
+        assert((*result.data.at(5)) == IntegerTrait::new(0, false), 'result[5] = 0');
+        assert((*result.data.at(6)) == IntegerTrait::new(0, false), 'result[6] = 0');
+        assert((*result.data.at(7)) == IntegerTrait::new(0, false), 'result[7] = 0');
+        assert((*result.data.at(8)) == IntegerTrait::new(1, false), 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_neg_last_axis() {
+        let tensor = i8_tensor_1x3_neg_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+         assert((*result.data.at(0)) == IntegerTrait::new(1, false), 'result[0] = 1');
+        assert((*result.data.at(1)) == IntegerTrait::new(0, false), 'result[1] = 0');
+        assert((*result.data.at(2)) == IntegerTrait::new(0, false), 'result[2] = 0');
+        assert((*result.data.at(3)) == IntegerTrait::new(0, false), 'result[3] = 0');
+        assert((*result.data.at(4)) == IntegerTrait::new(0, false), 'result[4] = 0');
+        assert((*result.data.at(5)) == IntegerTrait::new(1, false), 'result[5] = 1');
+        assert((*result.data.at(6)) == IntegerTrait::new(0, false), 'result[6] = 0');
+        assert((*result.data.at(7)) == IntegerTrait::new(1, false), 'result[7] = 1');
+        assert((*result.data.at(8)) == IntegerTrait::new(0, false), 'result[8] = 0');
+        }
+
+        #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_1x3_fail() {
+        let tensor = i8_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+    
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_Zero_axis() {
+        let tensor = i8_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data.at(0)) == IntegerTrait::new(1, false), 'result[0] = 1');
+        assert((*result.data.at(1)) == IntegerTrait::new(0, false), 'result[1] = 0');
+        assert((*result.data.at(2)) == IntegerTrait::new(0, false), 'result[2] = 0');
+        assert((*result.data.at(3)) == IntegerTrait::new(0, false), 'result[3] = 0');
+        assert((*result.data.at(4)) == IntegerTrait::new(1, false), 'result[4] = 1');
+        assert((*result.data.at(5)) == IntegerTrait::new(0, false), 'result[5] = 0');
+        assert((*result.data.at(6)) == IntegerTrait::new(0, false), 'result[6] = 0');
+        assert((*result.data.at(7)) == IntegerTrait::new(0, false), 'result[7] = 0');
+        assert((*result.data.at(8)) == IntegerTrait::new(1, false), 'result[8] = 1');
+        }
+
+}

--- a/src/tests/operators/tensor/math/onehot/onehot_u32_test.cairo
+++ b/src/tests/operators/tensor/math/onehot/onehot_u32_test.cairo
@@ -1,0 +1,451 @@
+use core::serde::Serde;
+use core::option::OptionTrait;
+use core::clone::Clone;
+// ===== 1D ===== //
+use orion::numbers::fixed_point::core::{FixedTrait, FixedType};
+
+#[cfg(test)]
+mod tensor_1D {
+    use array::{ArrayTrait, SpanTrait};
+    use core::traits::Into;
+
+    use orion::operators::tensor::implementations::impl_tensor_u32::Tensor_u32;
+    use orion::operators::tensor::core::{TensorTrait, ExtraParams, Tensor};
+    use orion::tests::helpers::tensor::u32::{u32_tensor_1x3_helper, u32_tensor_2x2_helper};
+
+
+     fn u32_tensor_3x2x2_new() -> Tensor<u32> {
+        let mut sizes = ArrayTrait::new();
+        sizes.append(3);
+        sizes.append(2);
+        sizes.append(2);
+
+        let mut data = ArrayTrait::new();
+        data.append(0);
+        data.append(1);
+        data.append(2);
+        data.append(3);
+        data.append(0);
+        data.append(1);
+        data.append(2);
+        data.append(3);
+        data.append(0);
+        data.append(1);
+        data.append(2);
+        data.append(3);
+
+        let extra = Option::<ExtraParams>::None(());
+
+        let tensor = TensorTrait::<u32>::new(sizes.span(), data.span(), extra);
+
+        return tensor;
+}
+
+    
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_last_axis() {
+        let tensor = u32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 1, 'result[4] = 1');
+        assert((*result.data[5]) == 0, 'result[5] = 0');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 1, 'result[8] = 1');
+        }
+    
+     #[test]
+
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_1x3_fail() {
+        let tensor = u32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+    
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_Zero_axis() {
+        let tensor = u32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 1, 'result[4] = 1');
+        assert((*result.data[5]) == 0, 'result[5] = 0');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 1, 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn tensor_onehot_1x3_axis_one() {
+        let tensor = u32_tensor_1x3_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 3;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 1, 'result[4] = 1');
+        assert((*result.data[5]) == 0, 'result[5] = 0');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 1, 'result[8] = 1');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_last_axis() {
+        let tensor = u32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 1, 'result[5] = 1');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 0, 'result[8] = 0');
+        assert((*result.data[9]) == 0, 'result[9] = 0');
+        assert((*result.data[10]) == 1, 'result[10] = 1');
+        assert((*result.data[11]) == 0, 'result[11] = 0');
+        assert((*result.data[12]) == 0, 'result[12] = 0');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[0] = 4');
+
+        }
+
+     #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_2x2_fail() {
+        let tensor = u32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_first_axis() {
+        let tensor = u32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 1, 'result[5] = 1');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 0, 'result[8] = 0');
+        assert((*result.data[9]) == 0, 'result[9] = 0');
+        assert((*result.data[10]) == 1, 'result[10] = 1');
+        assert((*result.data[11]) == 0, 'result[11] = 0');
+        assert((*result.data[12]) == 0, 'result[12] = 0');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_2x2_helper_second_axis() {
+        let tensor = u32_tensor_2x2_helper();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 1, 'result[3] = 1');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 0, 'result[5] = 0');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 0, 'result[8] = 0');
+        assert((*result.data[9]) == 0, 'result[9] = 0');
+        assert((*result.data[10]) == 0, 'result[10] = 1');
+        assert((*result.data[11]) == 0, 'result[11] = 0');
+        assert((*result.data[12]) == 1, 'result[12] = 1');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+
+        assert((*result.shape.at(0)) == 2, 'shape[0] = 2');
+        assert((*result.shape.at(1)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[0] = 2');
+
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_last_axis() {
+        let tensor = u32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::None(());
+        // let axis: Option<usize> = Option::Some(3);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 1, 'result[5] = 1');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 0, 'result[8] = 0');
+        assert((*result.data[9]) == 0, 'result[9] = 0');
+        assert((*result.data[10]) == 1, 'result[10] = 1');
+        assert((*result.data[11]) == 0, 'result[11] = 0');
+        assert((*result.data[12]) == 0, 'result[12] = 0');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+        assert((*result.data[16]) == 1, 'result[16] = 1');
+        assert((*result.data[21]) == 1, 'result[21] = 1');
+        assert((*result.data[26]) == 1, 'result[26] = 1');
+        assert((*result.data[31]) == 1, 'result[31] = 1');
+        assert((*result.data[32]) == 1, 'result[32] = 1');
+        assert((*result.data[37]) == 1, 'result[37] = 1');
+        assert((*result.data[42]) == 1, 'result[42] = 1');
+        assert((*result.data[46]) == 0, 'result[46] = 0');
+        assert((*result.data[47]) == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 2');
+        assert((*result.shape.at(3)) == 4, 'shape[0] = 4');
+        }
+
+    #[test]
+    #[should_panic]
+    #[available_gas(20000000)]
+    fn tensor_onehot_tensor_3x2x2_fail() {
+        let tensor = u32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(4);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+    }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_first_axis() {
+        let tensor = u32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(2);
+        values.append(5);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(0);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 5, 'result[0] = 5');
+        assert((*result.data[1]) == 2, 'result[1] = 2');
+        assert((*result.data[2]) == 2, 'result[2] = 2');
+        assert((*result.data[3]) == 2, 'result[3] = 2');
+        assert((*result.data[4]) == 5, 'result[4] = 5');
+        assert((*result.data[5]) == 2, 'result[5] = 2');
+        assert((*result.data[6]) == 2, 'result[6] = 2');
+        assert((*result.data[7]) == 2, 'result[7] = 2');
+        assert((*result.data[8]) == 5, 'result[8] = 5');
+        assert((*result.data[9]) == 2, 'result[9] = 2');
+        assert((*result.data[10]) == 2, 'result[10] = 2');
+        assert((*result.data[11]) == 2, 'result[11] = 2');
+        assert((*result.data[12]) == 2, 'result[12] = 2');
+        assert((*result.data[13]) == 5, 'result[13] = 5');
+        assert((*result.data[14]) == 2, 'result[14] = 2');
+        assert((*result.data[17]) == 5, 'result[17] = 5');
+        assert((*result.data[21]) == 5, 'result[21] = 5');
+        assert((*result.data[26]) == 5, 'result[26] = 5');
+        assert((*result.data[30]) == 5, 'result[30] = 5');
+        assert((*result.data[34]) == 5, 'result[34] = 5');
+        assert((*result.data[39]) == 5, 'result[39] = 5');
+        assert((*result.data[43]) == 5, 'result[43] = 5');
+        assert((*result.data[46]) == 2, 'result[46] = 2');
+        assert((*result.data[47]) == 5, 'result[47] = 5');
+
+        assert((*result.shape.at(0)) == 4, 'shape[0] = 4');
+        assert((*result.shape.at(1)) == 3, 'shape[1] = 3');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+     #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_second_axis() {
+        let tensor = u32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(1);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 0, 'result[3] = 0');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 1, 'result[5] = 1');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[7]) == 0, 'result[7] = 0');
+        assert((*result.data[8]) == 0, 'result[8] = 0');
+        assert((*result.data[9]) == 0, 'result[9] = 0');
+        assert((*result.data[10]) == 1, 'result[10] = 1');
+        assert((*result.data[11]) == 0, 'result[11] = 0');
+        assert((*result.data[12]) == 0, 'result[12] = 0');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+        assert((*result.data[16]) == 1, 'result[16] = 1');
+        assert((*result.data[21]) == 1, 'result[21] = 1');
+        assert((*result.data[26]) == 1, 'result[26] = 1');
+        assert((*result.data[31]) == 1, 'result[31] = 1');
+        assert((*result.data[32]) == 1, 'result[32] = 1');
+        assert((*result.data[37]) == 1, 'result[37] = 1');
+        assert((*result.data[42]) == 1, 'result[42] = 1');
+        assert((*result.data[46]) == 0, 'result[46] = 0');
+        assert((*result.data[47]) == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 4, 'shape[1] = 4');
+        assert((*result.shape.at(2)) == 2, 'shape[2] = 3');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+
+    #[test]
+    #[available_gas(20000000)]
+    fn fp_tensor_onehot_3x2x2_new_third_axis() {
+        let tensor = u32_tensor_3x2x2_new();
+
+        let mut values = ArrayTrait::new();
+        values.append(0);
+        values.append(1);
+        let depth = 4;
+        let axis: Option<usize> = Option::Some(2);
+
+        let result = tensor.onehot(depth:depth, axis:axis, values:values.span());
+
+        assert((*result.data[0]) == 1, 'result[0] = 1');
+        assert((*result.data[1]) == 0, 'result[1] = 0');
+        assert((*result.data[2]) == 0, 'result[2] = 0');
+        assert((*result.data[3]) == 1, 'result[3] = 1');
+        assert((*result.data[4]) == 0, 'result[4] = 0');
+        assert((*result.data[5]) == 0, 'result[5] = 0');
+        assert((*result.data[6]) == 0, 'result[6] = 0');
+        assert((*result.data[12]) == 1, 'result[12] = 1');
+        assert((*result.data[13]) == 0, 'result[13] = 0');
+        assert((*result.data[14]) == 0, 'result[14] = 0');
+        assert((*result.data[15]) == 1, 'result[15] = 1');
+        assert((*result.data[16]) == 1, 'result[16] = 1');
+        assert((*result.data[19]) == 1, 'result[19] = 1');
+        assert((*result.data[21]) == 0, 'result[21] = 0');
+        assert((*result.data[26]) == 0, 'result[26] = 0');
+        assert((*result.data[28]) == 1, 'result[28] = 1');
+        assert((*result.data[31]) == 1, 'result[31] = 1');
+        assert((*result.data[32]) == 1, 'result[32] = 1');
+        assert((*result.data[35]) == 1, 'result[35] = 1');
+        assert((*result.data[37]) == 0, 'result[37] = 0');
+        assert((*result.data[44]) == 1, 'result[44] = 1');
+        assert((*result.data[46]) == 0, 'result[46] = 0');
+        assert((*result.data[47]) == 1, 'result[47] = 1');
+
+        assert((*result.shape.at(0)) == 3, 'shape[0] = 3');
+        assert((*result.shape.at(1)) == 2, 'shape[1] = 2');
+        assert((*result.shape.at(2)) == 4, 'shape[2] = 4');
+        assert((*result.shape.at(3)) == 2, 'shape[0] = 2');
+        }
+}


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Produces a one-hot tensor based on inputs.

Issue Number: 127

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Produces a one-hot tensor based on inputs.
-  Test for fp, i8, i32 and u32.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
