### PR TITLE
⬆️ Fix cubit dependency

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/gizatechxyz/orion"
 
 [dependencies]
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "f37d73d" }
-cubit = { git = "https://github.com/raphaelDkhn/cubit.git" }
+cubit = { git = "https://github.com/influenceth/cubit.git", rev = "b459053" }
 
 [scripts]
 sierra = "cairo-compile . -r"


### PR DESCRIPTION
The `cubit` dependency has been switched from a fork to the `influenceth` repo since there is no more difference between those.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

N/A

Issue Number: #437 

## What is the new behavior?

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
