### PR TITLE
Fix(nodegen):  test generation for sequence outputs

### DIFF
--- a/nodegen/file_manager.py
+++ b/nodegen/file_manager.py
@@ -72,9 +72,9 @@ class CairoTest(File):
         super().__init__(os.path.join(BASE_PATH, file))
 
     @classmethod
-    def template(cls, name: str, arg_cnt: int, refs: list[str], func_sig: str) -> list[str]:
+    def base_template(cls, name: str, arg_cnt: int, refs: list[str], func_sig: str) -> list[str]:
         """
-        Create a template for a Cairo test function.
+        Create a template for a Cairo test function which expects a tensor output.
 
         Args:
             name (str): Name of the test function.
@@ -104,6 +104,42 @@ class CairoTest(File):
             *[f"    let y = {func_sig};"],
             *[ ""],
             *[ "    assert_eq(y, z);"],
+            *[ "}"],
+        ]
+
+    @classmethod
+    def sequence_template(cls, name: str, arg_cnt: int, refs: list[str], func_sig: str) -> list[str]:
+        """
+        Create a template for a Cairo test function which expects a tensor sequence.
+
+        Args:
+            name (str): Name of the test function.
+            arg_cnt (int): Number of arguments for the function.
+            refs (list[str]): List of references (modules) to be used in the function.
+            func_sig (str): The function signature.
+
+        Returns:
+            list[str]: A list of strings that together form the template of a Cairo test function.
+
+        This method generates a list of strings that form the template of a Cairo test function,
+        including module imports, function definition, and assertions.
+        """
+        return [
+            *[f"mod input_{i};" for i in range(arg_cnt)],
+            *[ "mod output_0;"],
+            *[ ""],
+            *[ ""],
+            *[f"use {ref};" for ref in refs],
+            *[ ""],
+            *[ "#[test]"],
+            *[ "#[available_gas(2000000000)]"],
+            *[f"fn test_{name}()"+" {"],
+            *[f"    let input_{i} = input_{i}::input_{i}();" for i in range(arg_cnt)],
+            *[ "    let z = output_0::output_0();"],
+            *[ ""],
+            *[f"    let y = {func_sig};"],
+            *[ ""],
+            *[ "    assert_seq_eq(y, z);"],
             *[ "}"],
         ]
 

--- a/nodegen/helpers.py
+++ b/nodegen/helpers.py
@@ -105,14 +105,14 @@ def make_test(inputs: list[Tensor | Sequence], output: Tensor | Sequence, func_s
             test_file.buffer = CairoTest.sequence_template(
                 name=name,
                 arg_cnt=len(inputs),
-                refs=get_all_test_refs(find_all_types([*inputs, *output]), trait, True),
+                refs=get_all_test_refs(find_all_types([*inputs, *output]), trait),
                 func_sig=func_sig,
             )
         case Tensor():
             test_file.buffer = CairoTest.base_template(
                 name=name,
                 arg_cnt=len(inputs),
-                refs=get_all_test_refs(find_all_types([*inputs, output]), trait, False),
+                refs=get_all_test_refs(find_all_types([*inputs, output]), trait),
                 func_sig=func_sig,
             )
 
@@ -147,15 +147,15 @@ def get_data_statement_for_sequences(data: Sequence, dtype: Dtype) -> list[list[
     return [get_data_statement(x.data, dtype) for x in data]
 
 
-def get_all_test_refs(dtypes: list[Dtype], trait: Trait, is_sequence: bool) -> list[str]:
+def get_all_test_refs(dtypes: list[Dtype], trait: Trait) -> list[str]:
     refs = []
     for dtype in dtypes:
-        refs += get_test_refs(dtype, trait, is_sequence)
+        refs += get_test_refs(dtype, trait)
 
     return list(set(refs))
 
 
-def get_test_refs(dtype: Dtype, trait: Trait, is_sequence: bool) -> list[str]:
+def get_test_refs(dtype: Dtype, trait: Trait) -> list[str]:
     dtype_ref = dtype_to_nn[dtype] if trait == Trait.NN else dtype_to_tensor[dtype]
     refs = [
         *trait_to_ref[trait],

--- a/nodegen/helpers.py
+++ b/nodegen/helpers.py
@@ -100,12 +100,22 @@ def make_test(inputs: list[Tensor | Sequence], output: Tensor | Sequence, func_s
     output_data.dump()
 
     test_file = CairoTest(f"{name}.cairo")
-    test_file.buffer = CairoTest.template(
-        name=name,
-        arg_cnt=len(inputs),
-        refs=get_all_test_refs(find_all_types([*inputs, output]), trait, isinstance(output, list)),
-        func_sig=func_sig,
-    )
+    match output:
+        case list():
+            test_file.buffer = CairoTest.sequence_template(
+                name=name,
+                arg_cnt=len(inputs),
+                refs=get_all_test_refs(find_all_types([*inputs, *output]), trait, True),
+                func_sig=func_sig,
+            )
+        case Tensor():
+            test_file.buffer = CairoTest.base_template(
+                name=name,
+                arg_cnt=len(inputs),
+                refs=get_all_test_refs(find_all_types([*inputs, output]), trait, False),
+                func_sig=func_sig,
+            )
+
     test_file.dump()
 
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In cases where the operator returns a sequence, `nodegen` uses the `assert_eq` function instead of `assert_seq_eq`. This causes a compilation error.

Issue Number: #336 

## What is the new behavior?

`nodegen` generates now valid tests for those cases.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->