### PR TITLE
fix: enable 1d tensor transpose

### DIFF
--- a/src/operators/tensor/linalg/transpose.cairo
+++ b/src/operators/tensor/linalg/transpose.cairo
@@ -11,7 +11,10 @@ use orion::numbers::NumberTrait;
 fn transpose<T, impl TTensor: TensorTrait<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>>(
     self: @Tensor<T>, axes: Span<usize>
 ) -> Tensor<T> {
-    assert((*self.shape).len() > 1, 'cannot transpose a 1D tensor');
+    if (*self.shape).len() == 1 {
+        return self.identity();
+    }
+
     assert(axes.len() == (*self.shape).len(), 'shape and axes length unequal');
 
     if (*self.shape).len() == 2 {

--- a/tests/operators/transpose_test.cairo
+++ b/tests/operators/transpose_test.cairo
@@ -25,6 +25,18 @@ fn transpose_test_values() {
     assert(result.data == array![0, 2, 4, 6, 1, 3, 5, 7].span(), 'wrong data');
 }
 
+#[test]
+#[available_gas(200000000000)]
+fn transpose_test_1D() {
+    let tensor = TensorTrait::<
+        u32
+    >::new(shape: array![4].span(), data: array![0, 1, 2, 3].span(),);
+
+    let result = tensor.transpose(axes: array![0].span());
+
+    assert(result.shape == array![4].span(), 'wrong shape');
+    assert(result.data == array![0, 1, 2, 3].span(), 'wrong data');
+}
 
 #[test]
 #[available_gas(200000000000)]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

This PR enables transposing of 1D tensors. This is also the default behaviour in other tensor libs.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If you try to transpose 1D tensor, the program panics.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

The program doesn't panic, but returns the same tensor as is the input.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->