### PR TITLE
Fix: Update project to work with Scarb 2.6.4

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 name = "orion"
 version = "0.2.5"
-cairo-version = "2.5.3"
+cairo-version = "2.6.3"
 edition = "2023_10"
 description = "ONNX Runtime in Cairo for verifiable ML inference using STARK"
 homepage = "https://github.com/gizatechxyz/orion"


### PR DESCRIPTION
#638 Issue Fixed


Used Scarb 2.6.4 and implemented  with cairo: 2.6.3

Run curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh -s -- -v 2.6.4
to downgrade


