### PR TITLE
Fix typos in `provable-mlr-forecasting-aaves-lifetime-repayments.md`

### DIFF
--- a/docs/academy/tutorials/provable-mlr-forecasting-aaves-lifetime-repayments.md
+++ b/docs/academy/tutorials/provable-mlr-forecasting-aaves-lifetime-repayments.md
@@ -562,11 +562,11 @@ impl RegressionOperation of MultipleLinearRegressionModelTrait {
 }
 
 fn MultipleLinearRegression(dataset: Dataset) -> MultipleLinearRegressionModel {
-    let x_values_tranposed = transpose_tensor(dataset.x_values);
-    let x_values_tranposed_with_bias = add_bias_term(x_values_tranposed, 0);
-    let decorrelated_x_features = decorrelate_x_features(x_values_tranposed_with_bias);
+    let x_values_transposed = transpose_tensor(dataset.x_values);
+    let x_values_transposed_with_bias = add_bias_term(x_values_transposed, 0);
+    let decorrelated_x_features = decorrelate_x_features(x_values_transposed_with_bias);
     let coefficients = compute_gradients(
-        decorrelated_x_features, dataset.y_values, x_values_tranposed_with_bias
+        decorrelated_x_features, dataset.y_values, x_values_transposed_with_bias
     );
     return MultipleLinearRegressionModel { coefficients };
 }

--- a/docs/academy/tutorials/provable-mlr-forecasting-aaves-lifetime-repayments.md
+++ b/docs/academy/tutorials/provable-mlr-forecasting-aaves-lifetime-repayments.md
@@ -299,14 +299,14 @@ Scarb is the Cairo package manager specifically created to streamline our Cairo 
 To create a new Scarb project, open your terminal and run:
 
 ```sh
-scarb new multiple_linear_regresion
+scarb new multiple_linear_regression
 ```
 
 A new project folder should be created for you and make sure to replace the content in Scarb.toml file with the following code:
 
 ```toml
 [package]
-name = "multiple_linear_regresion"
+name = "multiple_linear_regression"
 version = "0.1.0"
 [dependencies]
 orion = { git = "https://github.com/gizatechxyz/onnx-cairo" }
@@ -400,7 +400,7 @@ use orion::operators::tensor::{
     FP16x16TensorDiv, FP16x16TensorMul
 };
 use orion::numbers::{FP16x16, FixedTrait};
-use multiple_linear_regresion::helper_functions::{
+use multiple_linear_regression::helper_functions::{
     get_tensor_data_by_row, transpose_tensor, calculate_mean, calculate_r_score,
     normalize_user_x_inputs, rescale_predictions
 };
@@ -507,8 +507,8 @@ use orion::operators::tensor::{
     FP16x16TensorDiv, FP16x16TensorMul
 };
 use orion::numbers::{FP16x16, FixedTrait};
-use multiple_linear_regresion::data_preprocessing::{Dataset, DatasetTrait};
-use multiple_linear_regresion::helper_functions::{
+use multiple_linear_regression::data_preprocessing::{Dataset, DatasetTrait};
+use multiple_linear_regression::helper_functions::{
     get_tensor_data_by_row, transpose_tensor, calculate_mean, calculate_r_score,
     normalize_user_x_inputs, rescale_predictions
 };
@@ -1009,15 +1009,15 @@ At this stage, we have already implemented all the important sections of this tu
 use debug::PrintTrait;
 use array::{ArrayTrait, SpanTrait};
 
-use multiple_linear_regresion::datasets::aave_data::aave_x_features::aave_x_features;
-use multiple_linear_regresion::datasets::aave_data::aave_y_labels::aave_y_labels; 
-use multiple_linear_regresion::datasets::user_inputs_data::aave_weth_revenue_data_input::{aave_weth_revenue_data_input };  
+use multiple_linear_regression::datasets::aave_data::aave_x_features::aave_x_features;
+use multiple_linear_regression::datasets::aave_data::aave_y_labels::aave_y_labels; 
+use multiple_linear_regression::datasets::user_inputs_data::aave_weth_revenue_data_input::{aave_weth_revenue_data_input };  
 
-use multiple_linear_regresion::model::multiple_linear_regression_model::{
+use multiple_linear_regression::model::multiple_linear_regression_model::{
      MultipleLinearRegressionModel, MultipleLinearRegression, MultipleLinearRegressionModelTrait
 };
-use multiple_linear_regresion::data_preprocessing::{Dataset, DatasetTrait};
-use multiple_linear_regresion::helper_functions::{get_tensor_data_by_row, transpose_tensor, calculate_mean , 
+use multiple_linear_regression::data_preprocessing::{Dataset, DatasetTrait};
+use multiple_linear_regression::helper_functions::{get_tensor_data_by_row, transpose_tensor, calculate_mean , 
 calculate_r_score, normalize_user_x_inputs, rescale_predictions};
 
 use orion::numbers::{FP16x16,  FixedTrait};
@@ -1081,10 +1081,10 @@ Finally, we can execute the test file by running:
 ```shell
 >> scarb cairo-test -f multiple_linear_regression_test
 
-testing multiple_linear_regresion ...
+testing multiple_linear_regression ...
 running 1 tests
 
-test multiple_linear_regresion::test::multiple_linear_regression_test ... 
+test multiple_linear_regression::test::multiple_linear_regression_test ... 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 filtered out;
 ```
 


### PR DESCRIPTION
### Type of Change
- [x] Documentation content changes  

### Current Behavior
The tutorial document `provable-mlr-forecasting-aaves-lifetime-repayments.md` contained multiple spelling errors, specifically in the term **"multiple_linear_regresion"**, which was consistently misspelled throughout the file.

### New Behavior
- Fixed all instances of `"multiple_linear_regresion"` → `"multiple_linear_regression"`.  
- Adjusted related code references, function calls, and import paths accordingly.  
- Improved consistency in variable and function names to align with correct spelling.  

### Breaking Changes
- [ ] Yes  
- [x] No  
